### PR TITLE
Devel - Fixed error in HBPRINTER's END DOC command

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+- name: OOHG User Support Group
+    url: https://groups.google.com/forum/#!forum/oohg
+    about: Please ask and answer questions there.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,11 +12,37 @@
  *   '-' Removed: ...           ';' Comment
  */
 
+2020-06-12 23:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+   * core\include\winprint.ch
+   * core\source\winprint.prg
+     * Data PreviewMode is now PROTECTED when NO_GUI is defined.
+     ! Command END DOC.
+       When PREVIEW is OFF the execution is paused with a message
+       thus breaking the expected behaviour. This commit reserves
+       the changes made at 2019-01-18 19:12 UTC-0300.
+       The new syntax for the command is
+       END DOC [WAIT|NOWAIT] [SIZE|NOSIZE] [OF|PARENT]
+       Note that:
+       - SIZE and NOSIZE are ignored if PREVIEW is OFF.
+       - if SIZE and NOSIZE clauses are omitted, SIZE is assumed
+         when WAIT is set (explicitly or assumed).
+       - WAIT is assumed when PREVIEW is ON.
+       - NOWAIT is assumed when PREVIEW is OFF.
+
+2020-06-11 23:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+   * core\source\winprint.prg
+     ! When PREVIEW is OFF a message pops up indicating that the
+       report is empty.
+
+2020-06-11 23:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+   * core\include\oohgversion.h
+     ! __OOHG__ has wrong value.
+
 2020-06-11 17:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
    + core\.github\ISSUE_TEMPLATE\config.yml
      ; Contact information.
 
-2020-06-11 18:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+2020-06-11 17:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
    * core\resources\_oohg_resconfig.h
      ! Wrong path.
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,7 +12,7 @@
  *   '-' Removed: ...           ';' Comment
  */
 
-2020-06-12 23:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+2020-06-12 09:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
    * core\include\winprint.ch
    * core\source\winprint.prg
      * Data PreviewMode is now PROTECTED when NO_GUI is defined.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,6 +12,14 @@
  *   '-' Removed: ...           ';' Comment
  */
 
+2020-06-11 17:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+   + core\.github\ISSUE_TEMPLATE\config.yml
+     ; Contact information.
+
+2020-06-11 18:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+   * core\resources\_oohg_resconfig.h
+     ! Wrong path.
+
 2020-06-10 19:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
    * core\ChangeLog_006.txt
      ! Typo.

--- a/include/oohgversion.h
+++ b/include/oohgversion.h
@@ -87,6 +87,6 @@
 #define OOHG_NAME             "Object Oriented (x)Harbour GUI"
 #define OOHG_COMPANY_NAME     "OOHG Project"
 
-#define __OOHG__              0x13021B   /* Three bytes: Major + Minor + Build. */
+#define __OOHG__              0x140608   /* Three bytes: Major + Minor + Build. */
 
 #endif /* OOHG_VER_H_ */

--- a/include/winprint.ch
+++ b/include/winprint.ch
@@ -167,9 +167,41 @@ MEMVAR HBPRN
       iif( __DYNSISFUN( "TAPPLICATION" ) .AND. _OOHG_ActiveFrame # NIL, Do( "_EndTabPage" ), hbprn:EndPage() )
 #endif
 
-#xcommand END DOC [ <nowait: NOWAIT> ] [ <size: SIZE> ] [ <dummy: OF, PARENT> <parent> ] ;
+#xcommand END DOC [ <dummy: OF, PARENT> <parent> ] ;
    => ;
-      hbprn:EndDoc( <(parent)>, ! <.nowait.>, <.size.> )
+      hbprn:EndDoc( <(parent)>, NIL, NIL )
+
+#xcommand END DOC NOWAIT [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, .F., NIL )
+
+#xcommand END DOC WAIT [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, .T., NIL )
+
+#xcommand END DOC SIZE [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, NIL, .T. )
+
+#xcommand END DOC NOSIZE [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, NIL, .F. )
+
+#xcommand END DOC NOWAIT SIZE [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, .F., .T. )
+
+#xcommand END DOC NOWAIT NOSIZE [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, .F., .F. )
+
+#xcommand END DOC WAIT SIZE [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, .T., .T. )
+
+#xcommand END DOC WAIT NOSIZE [ <dummy: OF, PARENT> <parent> ] ;
+   => ;
+      hbprn:EndDoc( <(parent)>, .T., .F. )
 
 #xcommand RELEASE PRINTSYS ;
    => ;

--- a/resources/_oohg_resconfig.h
+++ b/resources/_oohg_resconfig.h
@@ -1,2 +1,2 @@
 #define oohgpath C:\OOHG\RESOURCES
-#include "C:\OOHG\RESOURCES\oohgversion.h"
+#include "C:\OOHG\INCLUDE\oohgversion.h"

--- a/source/winprint.prg
+++ b/source/winprint.prg
@@ -3145,13 +3145,13 @@ METHOD Preview( cParent, lWait, lSize ) CLASS HBPrinter
 
    LOCAL i, cName, oSplit, oPages, oImg
 
-   ::IloscStron := Len( ::MetaFiles )
-   IF ::IloscStron < 1
-      MsgStop( ::aOpisy[ 51 ], "" )
+   IF ! ::PreviewMode
       RETURN NIL
    ENDIF
 
-   IF ! ::PreviewMode
+   ::IloscStron := Len( ::MetaFiles )
+   IF ::IloscStron < 1
+      MsgStop( ::aOpisy[ 51 ], "" )
       RETURN NIL
    ENDIF
 

--- a/source/winprint.prg
+++ b/source/winprint.prg
@@ -237,7 +237,11 @@ CLASS HBPrinter
    DATA Pens                      INIT { {}, {} }
    DATA PolyFillMode              INIT POLYFILL_ALTERNATE
    DATA Ports                     INIT {}
+#ifndef NO_GUI
    DATA PreviewMode               INIT .F.
+#else
+   DATA PreviewMode               INIT .F. PROTECTED
+#endif
    DATA PreviewRect               INIT { 0, 0, 0, 0 }
    DATA PreviewScale              INIT 1
    DATA PrinterDefault            INIT ""
@@ -405,11 +409,7 @@ METHOD SelectPrinter( cPrinter, lPrev ) CLASS HBPrinter
    ENDIF
    IF HB_ISLOGICAL( lPrev )
       #ifndef NO_GUI
-         IF lprev
-            ::PreviewMode := .T.
-         ENDIF
-      #else
-         ::PreviewMode := .F.
+         ::PreviewMode := lPrev
       #endif
    ENDIF
    IF ::hDC == 0
@@ -566,10 +566,11 @@ METHOD EndDoc( cParent, lWait, lSize ) CLASS HBPrinter
       lSize := ! lWait
    ENDIF
 
+   IF ::PreviewMode
 #ifndef NO_GUI
-   ::Preview( cParent, lWait, lSize )
+      ::Preview( cParent, lWait, lSize )
 #endif
-   IF ! ::PreviewMode
+   ELSE
       IF lWait
          MsgInfo( ::aOpisy[ 31 ], "" )
       ENDIF


### PR DESCRIPTION
The fix at HBPRINTER restores the expected behaviour of END DOC command.
The path in file resources\_oohg_resconfig is not pointing to C:.
__OOHG__ symbol wasn't updated on last release.  