### PR TITLE
Devel - Improvement at checkbox and button, fixed transparent controls over an image

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -12,3584 +12,3641 @@
  *   '-' Removed: ...           ';' Comment
  */
 
+2020-06-14 19:05 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+  * core\source\h_application.prg
+    + MAX_OBJ_NUMBER constant.
+    * Changed the behaviour of function _OOHG_GetNullName:
+      instead of restarting from 0 when it's maximun value is
+      reached (which leads to a fatal error caused by trying
+      to create an object with the same name of an already
+      existing one) now it will end the app with a specific
+      error message. If your app is going to create more than
+      10.000.000.000 objects you must modify the value of the
+      constant MAX_OBJ_NUMBER and recompile OOHG libraries.
+
+2020-06-14 19:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+  * core\source\h_radio.prg
+    * Classes TRadioGroup and TRadioItem: if neither WINDRAW
+      nor OOHGDRAW clauses are present then the first one will
+      be assumed when FONTCOLOR clause is specified and the
+      app is themed.
+    * DATA lLibDraw of class TRadioGroup now defaults to
+      _OOHG_UseLibraryDraw instead of .F.
+    + Method oBkGrnd to class TRadioGroup. It's an improved
+      version of older method Background: you can now remove
+      the background by passing NIL as parameter.
+    * Method Background of classes TRadioGroup and TRadioItem
+      now just call method oBkGrnd.
+
+2020-06-14 19:01 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+  * core\source\h_controlmisc.prg
+    ! The focus rectangle is not erased when a checkbox with
+      BACKGROUND clause looses the focus. This was caused by
+      creating the brush in each paint cycle. From now on the
+      brush is created on the first paint cycle and reused in
+      every subsequent cycle.
+    + Data BackgroundObject to class TControl.
+    - Data oBkGrnd from class TControl.
+    + Method oBkGrnd to class TControl.
+    ; This changes allow to remove or replace the background object
+      of a control after its creation.
+    ! Method Events_Color of class TControl: a control which has
+      a background object assigned shows a focus rectangle after
+      loosing the focus.
+
+2020-06-14 18:59 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+  * core\source\h_button.prg
+    * If neither WINDRAW nor OOHGDRAW clauses are present then
+      the first one will be assumed when FONTCOLOR clause is
+      specified and the app is themed.
+
+2020-06-14 18:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
+  * core\source\h_checkbox.prg
+    * If neither WINDRAW nor OOHGDRAW clauses are present then
+      the first one will be assumed when NOFOCUSRECT of FONTCOLOR
+      clauses are specified and the app is themed.
+    * DATA lLibDraw now defaults to _OOHG_UseLibraryDraw
+      instead of .F.
+
 2020-06-12 09:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\winprint.ch
-   * core\source\winprint.prg
-     * Data PreviewMode is now PROTECTED when NO_GUI is defined.
-     ! Command END DOC.
-       When PREVIEW is OFF the execution is paused with a message
-       thus breaking the expected behaviour. This commit reserves
-       the changes made at 2019-01-18 19:12 UTC-0300.
-       The new syntax for the command is
-       END DOC [WAIT|NOWAIT] [SIZE|NOSIZE] [OF|PARENT]
-       Note that:
-       - SIZE and NOSIZE are ignored if PREVIEW is OFF.
-       - if SIZE and NOSIZE clauses are omitted, SIZE is assumed
-         when WAIT is set (explicitly or assumed).
-       - WAIT is assumed when PREVIEW is ON.
-       - NOWAIT is assumed when PREVIEW is OFF.
+  * core\include\winprint.ch
+  * core\source\winprint.prg
+    * Data PreviewMode is now PROTECTED when NO_GUI is defined.
+    ! Command END DOC.
+      When PREVIEW is OFF the execution is paused with a message
+      thus breaking the expected behaviour. This commit reserves
+      the changes made at 2019-01-18 19:12 UTC-0300.
+      The new syntax for the command is
+      END DOC [WAIT|NOWAIT] [SIZE|NOSIZE] [OF|PARENT]
+      Note that:
+      SIZE and NOSIZE are ignored if PREVIEW is OFF.
+      If SIZE and NOSIZE clauses are omitted, SIZE is assumed
+      when WAIT is set (explicitly or assumed).
+      WAIT is assumed when PREVIEW is ON.
+      NOWAIT is assumed when PREVIEW is OFF.
 
 2020-06-11 23:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     ! When PREVIEW is OFF a message pops up indicating that the
-       report is empty.
+  * core\source\winprint.prg
+    ! When PREVIEW is OFF a message pops up indicating that the
+      report is empty.
 
 2020-06-11 23:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohgversion.h
-     ! __OOHG__ has wrong value.
+  * core\include\oohgversion.h
+    ! __OOHG__ has wrong value.
 
 2020-06-11 17:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   + core\.github\ISSUE_TEMPLATE\config.yml
-     ; Contact information.
+  + core\.github\ISSUE_TEMPLATE\config.yml
+    ; Contact information.
 
 2020-06-11 17:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\resources\_oohg_resconfig.h
-     ! Wrong path.
+  * core\resources\_oohg_resconfig.h
+    ! Wrong path.
 
 2020-06-10 19:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\ChangeLog_006.txt
-     ! Typo.
+  * core\ChangeLog_006.txt
+    ! Typo.
 
 2020-06-08 22:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-   * core\include\i_browse.ch
-   * core\include\i_grid.ch
-   * core\include\i_xbrowse.ch
-     + Clause TIMEOUT.
-       Sets a common timeout for all edit controls without it's
-       own timeout (0 means no timeout). All edit controls inherit
-       this value if they do not have a specific timeout.
-       By default the common timeout is set to NIL meaning that the
-       edit controls without a specific timeout will default to
-       the value set by class TGridControl.
-   * Tagged as v20.06.08.rc1
+  * core\include\i_altsyntax.ch
+  * core\include\i_browse.ch
+  * core\include\i_grid.ch
+  * core\include\i_xbrowse.ch
+    + Clause TIMEOUT.
+      Sets a common timeout for all edit controls without it's
+      own timeout (0 means no timeout). All edit controls inherit
+      this value if they do not have a specific timeout.
+      By default the common timeout is set to NIL meaning that the
+      edit controls without a specific timeout will default to
+      the value set by class TGridControl.
+  * Tagged as v20.06.08.rc1
 
 2020-06-08 22:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-     ! HeaderColors is not reseted before defining an XBrowse.
+  * core\include\i_altsyntax.ch
+    ! HeaderColors is not reseted before defining an XBrowse.
 
 2020-06-08 22:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_window.ch
-     * Use defines instead of values.
+  * core\include\i_window.ch
+    * Use defines instead of values.
 
 2020-06-08 22:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_gdiplus.c
-     ! Function GPlusLoadImageFromFile is not working properly
-       and generates a RTE.
+  * core\source\c_gdiplus.c
+    ! Function GPlusLoadImageFromFile is not working properly
+      and generates a RTE.
 
 2020-06-08 22:09 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_windows.c
-     ! Function WindowExStyleFlag is not working properly.
+  * core\source\c_windows.c
+    ! Function WindowExStyleFlag is not working properly.
 
 2020-06-08 22:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_browse.prg
-   * core\source\h_grid.prg
-   * core\source\h_xbrowse.prg
-     + TGridControl class now supports a timeout to automatically
-       end the control's edition after a prefixed amount of time.
-       Note that the timeout begins when the edition starts and
-       goes uninterrupted by any user action.
-       If no timeout is specified, the grid's timeout is used if
-       it's not NIL, in which case defaults to 0 = 'no timeout'.
+  * core\source\h_browse.prg
+  * core\source\h_grid.prg
+  * core\source\h_xbrowse.prg
+    + TGridControl class now supports a timeout to automatically
+      end the control's edition after a prefixed amount of time.
+      Note that the timeout begins when the edition starts and
+      goes uninterrupted by any user action.
+      If no timeout is specified, the grid's timeout is used if
+      it's not NIL, in which case defaults to 0 = 'no timeout'.
 
 2020-06-08 22:04 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! Hidden column becames visible after executing methods
-       ColumnAutoFit, ColumnAutoFitH, ColumnBetterAutofit,
-       ColumnsBetterAutofit, ColumnsAutoFit and ColumnsAutofitH.
+  * core\source\h_grid.prg
+    ! Hidden column becames visible after executing methods
+      ColumnAutoFit, ColumnAutoFitH, ColumnBetterAutofit,
+      ColumnsBetterAutofit, ColumnsAutoFit and ColumnsAutofitH.
 
 2020-06-08 21:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     ! In a TXBroseByCell, after editing cell in column 2 the
-       same cell is edited again.
+  * core\source\h_xbrowse.prg
+    ! In a TXBroseByCell, after editing cell in column 2 the
+      same cell is edited again.
 
 2020-06-08 00:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_dll.prg
-     * Calls to function GetProcAddress were replaced by a call to
-       function _OOHG_GetProcAddress to pacify MinGW warning.
+  * core\source\h_dll.prg
+    * Calls to function GetProcAddress were replaced by a call to
+      function _OOHG_GetProcAddress to pacify MinGW warning.
 
 2020-06-07 22:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-06-07 22:43 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_error.prg
-     ! Language support.
+  * core\source\h_error.prg
+    ! Language support.
 
 2020-06-07 22:42 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     ! Missing languages.
+  * core\source\h_init.prg
+    ! Missing languages.
 
 2020-06-07 15:09 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\BuildApp_hbmk2.bat
-     + Switch /NOHBC to prevent the forced addition of OOHG.HBC
-       to HBMK2 command line.
+  * core\BuildApp_hbmk2.bat
+    + Switch /NOHBC to prevent the forced addition of OOHG.HBC
+      to HBMK2 command line.
 
 2020-06-07 15:06 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile.bat
-     ! Wrong syntax in the content of var HG_INC_CCOMP breaks
-       compilation.
+  * core\compile.bat
+    ! Wrong syntax in the content of var HG_INC_CCOMP breaks
+      compilation.
 
 2020-06-07 15:02 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_MINGW.BAT
-   * core\compile_bcc.bat
-     ! Console programs don't show output when started.
+  * core\compile_MINGW.BAT
+  * core\compile_bcc.bat
+    ! Console programs don't show output when started.
 
 2020-06-07 15:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.h
-     + Prototype of function _OOHG_ChangeWindowMessageFilter.
+  * core\include\oohg.h
+    + Prototype of function _OOHG_ChangeWindowMessageFilter.
 
 2020-06-07 14:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     * Some typedef were renamed to improve uniformity.
-     * Function _OOHG_ChangeWindowMessageFilter.
+  * core\source\c_winapimisc.c
+    * Some typedef were renamed to improve uniformity.
+    * Function _OOHG_ChangeWindowMessageFilter.
 
 2020-06-07 14:54 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     * Some casting to pacify C compiler.
+  * core\source\bostaurus.prg
+    * Some casting to pacify C compiler.
 
 2020-06-07 14:52 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     - Style WS_EX_COMPOSITED generates flicker.
-     + Set AcceptFiles to .F. at method Destroy.
+  * core\source\h_form.prg
+    - Style WS_EX_COMPOSITED generates flicker.
+    + Set AcceptFiles to .F. at method Destroy.
 
 2020-06-07 14:49 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! App freezes when a grid, xbrowse or browse control is
-       defined without columns.
+  * core\source\h_grid.prg
+    ! App freezes when a grid, xbrowse or browse control is
+      defined without columns.
 
 2020-06-07 14:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_report.ch
-     + Clause NAME to DO REPORT and REPORTFORMWIN commands.
-       Use it to name the report when is output to a file.
-   * core\source\h_report.prg
-     + Support for clause NAME.
+  * core\include\i_report.ch
+    + Clause NAME to DO REPORT and REPORTFORMWIN commands.
+      Use it to name the report when is output to a file.
+  * core\source\h_report.prg
+    + Support for clause NAME.
 
 2020-06-07 14:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     ! Compilation error under xHarbour because destroyer must be
-       a Procedure instead of Method.
-     * Function ParseName now accepts a path if it's ended with
-       a backslash char. In such a case 'list' is set as filename.
-     - Unneeded defines and includes at C level.
+  * core\source\h_print.prg
+    ! Compilation error under xHarbour because destroyer must be
+      a Procedure instead of Method.
+    * Function ParseName now accepts a path if it's ended with
+      a backslash char. In such a case 'list' is set as filename.
+    - Unneeded defines and includes at C level.
 
 2020-06-07 14:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     * Some format.
-     ! Method AcceptFile is not working because WM_DROPFILES
-       messages are blocked by User Interface Privilege Isolation.
-     ! Memory leak at WM_DROPFILES handler.
+  * core\source\h_windows.prg
+    * Some format.
+    ! Method AcceptFile is not working because WM_DROPFILES
+      messages are blocked by User Interface Privilege Isolation.
+    ! Memory leak at WM_DROPFILES handler.
 
 2020-06-07 14:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-     ! Lib shows an error message when a printer option is not
-       supported by it's drivers even if warnings were disabled.
+  * core\source\miniprint.prg
+    ! Lib shows an error message when a printer option is not
+      supported by it's drivers even if warnings were disabled.
 
 2020-06-07 14:18 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.hbp
-   * core\source\hbprinter.hbp
-   * core\source\miniprint.hbp
-   * core\source\oohg.hbp
-     * Some warnings for clang64 compiler.
+  * core\source\bostaurus.hbp
+  * core\source\hbprinter.hbp
+  * core\source\miniprint.hbp
+  * core\source\oohg.hbp
+    * Some warnings for clang64 compiler.
 
 2020-06-06 00:50 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohgversion.h
-     * Version bumped to release candidate 1 instead of beta.
+  * core\include\oohgversion.h
+    * Version bumped to release candidate 1 instead of beta.
 
 2020-06-06 00:49 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile.bat
-   * core\compile_bcc.bat
-   * core\compile_MINGW.BAT
-     + Support for customized include paths in RC, Harbour and
-       C compilers. Set envvars HG_INC_RC, HG_INC_HRB and/or
-       HG_INC_CCOMP to add folders.
-     - Support for /O, /Z, /A and /M switches.
-       Use HG_ADDLIBS instead.
+  * core\compile.bat
+  * core\compile_bcc.bat
+  * core\compile_MINGW.BAT
+    + Support for customized include paths in RC, Harbour and
+      C compilers. Set envvars HG_INC_RC, HG_INC_HRB and/or
+      HG_INC_CCOMP to add folders.
+    - Support for /O, /Z, /A and /M switches.
+      Use HG_ADDLIBS instead.
 
 2020-06-06 00:36 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! Method EditItem2 is not displaying the valid message.
-     ! Missing message wnindow title.
+  * core\source\h_grid.prg
+    ! Method EditItem2 is not displaying the valid message.
+    ! Missing message wnindow title.
 
 2020-06-05 17:55 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     ! App is blocked if a TPrint object is destroyed without
-       executing method Release.
-     + Destroyer method Destroy to class TPrint.
+  * core\source\h_print.prg
+    ! App is blocked if a TPrint object is destroyed without
+      executing method Release.
+    + Destroyer method Destroy to class TPrint.
 
 2020-06-04 20:42 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-06-04 20:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_activex.c
-   * core\source\h_activex.prg
-     + Error message in case the ocx cannot be instantiated.
+  * core\source\c_activex.c
+  * core\source\h_activex.prg
+    + Error message in case the ocx cannot be instantiated.
 
 2020-05-02 17:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_menu.prg
-     * Use new macros to get parameters without explicity using
-       HB_PARNL macro. This enables future use of pointers.
-     ! Bitmap casting at function InsertMenu and AppendMenu.
+  * core\source\h_menu.prg
+    * Use new macros to get parameters without explicity using
+      HB_PARNL macro. This enables future use of pointers.
+    ! Bitmap casting at function InsertMenu and AppendMenu.
 
 2020-05-02 17:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     * Use new macros to get parameters without explicity using
-       HB_PARNL macro. This enables future use of pointers.
-     + Functions SetWindowLongPtr and GetWindowLongPtr.
+  * core\source\c_winapimisc.c
+    * Use new macros to get parameters without explicity using
+      HB_PARNL macro. This enables future use of pointers.
+    + Functions SetWindowLongPtr and GetWindowLongPtr.
 
 2020-05-02 17:23 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_activex.c
-   * core\source\c_controlmisc.c
-   * core\source\c_msgbox.c
-   * core\source\c_windows.c
-   * core\source\h_button.prg
-   * core\source\h_controlmisc.prg
-   * core\source\h_dll.prg
-   * core\source\h_form.prg
-   * core\source\h_frame.prg
-   * core\source\h_grid.prg
-   * core\source\h_image.prg
-   * core\source\h_internal.prg
-   * core\source\h_listbox.prg
-   * core\source\h_menu.prg
-   * core\source\h_monthcal.prg
-   * core\source\h_picture.prg
-   * core\source\h_progressmeter.prg
-   * core\source\h_registry.prg
-   * core\source\h_richeditbox.prg
-   * core\source\h_textarray.prg
-   * core\source\h_textbox.prg
-   * core\source\h_toolbar.prg
-   * core\source\h_tooltip.prg
-   * core\source\h_tree.prg
-   * core\source\h_windows.prg
-   * core\source\winprint.prg
-     * Use new macros to get parameters without explicity using
-       HB_PARNL macro. This enables future use of pointers.
+  * core\source\c_activex.c
+  * core\source\c_controlmisc.c
+  * core\source\c_msgbox.c
+  * core\source\c_windows.c
+  * core\source\h_button.prg
+  * core\source\h_controlmisc.prg
+  * core\source\h_dll.prg
+  * core\source\h_form.prg
+  * core\source\h_frame.prg
+  * core\source\h_grid.prg
+  * core\source\h_image.prg
+  * core\source\h_internal.prg
+  * core\source\h_listbox.prg
+  * core\source\h_menu.prg
+  * core\source\h_monthcal.prg
+  * core\source\h_picture.prg
+  * core\source\h_progressmeter.prg
+  * core\source\h_registry.prg
+  * core\source\h_richeditbox.prg
+  * core\source\h_textarray.prg
+  * core\source\h_textbox.prg
+  * core\source\h_toolbar.prg
+  * core\source\h_tooltip.prg
+  * core\source\h_tree.prg
+  * core\source\h_windows.prg
+  * core\source\winprint.prg
+    * Use new macros to get parameters without explicity using
+      HB_PARNL macro. This enables future use of pointers.
 
 2020-05-02 17:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-05-02 17:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.h
-     + Macros HPALETTEparam, DEVICEINTERFASEparam, DRAWITEMSTRUCTparam,
-       HELPINFOparam, LV_KEYDOWNparam, MSGBOXCALLBACKparam, MYITEMparam,
-       NMCUSTOMDRAWparam, NMDAYSTATEparam, NMHDRparam, NMHEADERparam,
-       NMITEMACTIVATEparam, NMLISTVIEWparam, NMLVDISPINFOparam,
-       NMLVSCROLLparam, NMMOUSEparam, NMTTDISPINFOparam, LONG_PTRparam,
-       NMVIEWCHANGEparam, LPARAMparam, LPRECTparam, REGSAMparam,
-       ULONG_PTRparam, WPARAMparam.
+  * core\include\oohg.h
+    + Macros HPALETTEparam, DEVICEINTERFASEparam, DRAWITEMSTRUCTparam,
+      HELPINFOparam, LV_KEYDOWNparam, MSGBOXCALLBACKparam, MYITEMparam,
+      NMCUSTOMDRAWparam, NMDAYSTATEparam, NMHDRparam, NMHEADERparam,
+      NMITEMACTIVATEparam, NMLISTVIEWparam, NMLVDISPINFOparam,
+      NMLVSCROLLparam, NMMOUSEparam, NMTTDISPINFOparam, LONG_PTRparam,
+      NMVIEWCHANGEparam, LPARAMparam, LPRECTparam, REGSAMparam,
+      ULONG_PTRparam, WPARAMparam.
 
 2020-05-31 20:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-05-31 20:43 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     * Use new macros to get parameters without explicity using
-       HB_PARNL macro. This enables future use of pointers.
-     * Some casting.
-     * Parameters type of function bt_bmp_SaveFile.
+  * core\source\bostaurus.prg
+    * Use new macros to get parameters without explicity using
+      HB_PARNL macro. This enables future use of pointers.
+    * Some casting.
+    * Parameters type of function bt_bmp_SaveFile.
 
 2020-05-31 20:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_gdiplus.c
-     * Parameters type of function SaveHBitmapToFile.
+  * core\source\c_gdiplus.c
+    * Parameters type of function SaveHBitmapToFile.
 
 2020-05-31 20:37 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.h
-     + Macros HB_PARPTR3, DRAWITEMSTRUCTparam, HBPRINTERDATAparam,
-       HSINKparam, MEASUREITEMSTRUCTparam, MSGFILTERparam,
-       NMTBGETINFOTIPparam, NMTOOLBARparam, TOOLTIPTEXTparam,
-       HIMAGELISTparam3, HBITMAPparam2, HDCparam2, HGDIOBJparam2.
+  * core\include\oohg.h
+    + Macros HB_PARPTR3, DRAWITEMSTRUCTparam, HBPRINTERDATAparam,
+      HSINKparam, MEASUREITEMSTRUCTparam, MSGFILTERparam,
+      NMTBGETINFOTIPparam, NMTOOLBARparam, TOOLTIPTEXTparam,
+      HIMAGELISTparam3, HBITMAPparam2, HDCparam2, HGDIOBJparam2.
 
 2020-05-31 20:36 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_active.c
-   * core\source\c_controlmisc.c
-   * core\source\c_cursor.c
-   * core\source\c_font.c
-   * core\source\c_graph.c
-   * core\source\c_image.c
-   * core\source\c_msgbox.c
-   * core\source\c_resource.c
-   * core\source\c_winapimisc.c
-   * core\source\h_combo.prg
-   * core\source\h_controlmisc.prg
-   * core\source\h_media.prg
-   * core\source\h_listbox.prg
-   * core\source\h_menu.prg
-   * core\source\h_notify.prg
-   * core\source\h_registry.prg
-   * core\source\h_richeditbox.prg
-   * core\source\h_toolbar.prg
-   * core\source\h_windows.prg
-   * core\source\miniprint.prg
-   * core\source\winprint.prg
-     * Use new macros to get parameters without explicity using
-       HB_PARNL macro. This enables future use of pointers.
+  * core\source\c_active.c
+  * core\source\c_controlmisc.c
+  * core\source\c_cursor.c
+  * core\source\c_font.c
+  * core\source\c_graph.c
+  * core\source\c_image.c
+  * core\source\c_msgbox.c
+  * core\source\c_resource.c
+  * core\source\c_winapimisc.c
+  * core\source\h_combo.prg
+  * core\source\h_controlmisc.prg
+  * core\source\h_media.prg
+  * core\source\h_listbox.prg
+  * core\source\h_menu.prg
+  * core\source\h_notify.prg
+  * core\source\h_registry.prg
+  * core\source\h_richeditbox.prg
+  * core\source\h_toolbar.prg
+  * core\source\h_windows.prg
+  * core\source\miniprint.prg
+  * core\source\winprint.prg
+    * Use new macros to get parameters without explicity using
+      HB_PARNL macro. This enables future use of pointers.
 
 2020-05-31 16:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     * TEXT macro replace by _TEXT.
+  * core\source\bostaurus.prg
+    * TEXT macro replace by _TEXT.
 
 2020-05-31 16:35 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile.bat
-     + Lib rddads from HB_ADDLIBS default list.
-       Set it explicitly or use compile.bat /A switch to include it.
+  * core\compile.bat
+    + Lib rddads from HB_ADDLIBS default list.
+      Set it explicitly or use compile.bat /A switch to include it.
 
 2020-05-31 16:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-     * Some format.
+  * core\include\i_altsyntax.ch
+    * Some format.
 
 2020-05-31 16:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! Dynamic colors of grid, browse and xbrowse controls
-       are lost after scrolling.
+  * core\source\h_grid.prg
+    ! Dynamic colors of grid, browse and xbrowse controls
+      are lost after scrolling.
 
 2020-05-31 16:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_controlmisc.c
-   * core\source\c_winapimisc.c
-   * core\source\c_windows.c
-   * core\source\h_richeditbox.prg
-   * core\source\h_textbox.prg
-     * Some clang warnings pacified.
+  * core\source\c_controlmisc.c
+  * core\source\c_winapimisc.c
+  * core\source\c_windows.c
+  * core\source\h_richeditbox.prg
+  * core\source\h_textbox.prg
+    * Some clang warnings pacified.
 
 2020-05-31 16:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.hbp
-   * core\source\hbprinter.hbp
-   * core\source\miniprint.hbp
-   * core\source\oohg.hbp
-     * Some warnings for clang compiler.
+  * core\source\bostaurus.hbp
+  * core\source\hbprinter.hbp
+  * core\source\miniprint.hbp
+  * core\source\oohg.hbp
+    * Some warnings for clang compiler.
 
 2020-05-30 18:02 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_controlmisc.c
-     + Casting to pacify C compiler warning.
+  * core\source\c_controlmisc.c
+    + Casting to pacify C compiler warning.
 
 2020-05-30 12:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\oohg_license_template.txt
-   * core\include\*.ch
-   * core\include\*.h
-   * core\source\*.c
-   * core\source\*.prg
-     * Copyright updated.
+  * core\oohg_license_template.txt
+  * core\include\*.ch
+  * core\include\*.h
+  * core\source\*.c
+  * core\source\*.prg
+    * Copyright updated.
 
 2020-05-30 11:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohgversion.h
-     * Updated version info to next intended one.
-     ! Unused OOHG_VER_PROD_VER define.
+  * core\include\oohgversion.h
+    * Updated version info to next intended one.
+    ! Unused OOHG_VER_PROD_VER define.
 
 2020-05-30 11:04 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_pseudofunc.h
-     + Lib's build status to version.
+  * core\include\i_pseudofunc.h
+    + Lib's build status to version.
 
 2020-05-30 10:15 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_active.c
-     ! Wrong order of #include breaks app building with message
-       "hb_stack not defined".
+  * core\source\c_active.c
+    ! Wrong order of #include breaks app building with message
+      "hb_stack not defined".
 
 2020-05-29 21:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.h
-     * Some format.
-     * Macro HB_STORNL2 renamed to HB_STORNL.
-     * Macro HB_STORPTR renamed to HB_STORPTR3.
-     + Macro HB_STORPTR.
-     + Macros HANDLEparam, HBITMAPparam, HBRUSHparam, HCURSORparam,
-       HDCparam, HEMFparam, HFONTparam, HGDIOBJparam, HGLOBALparam,
-       HICparam, HICONparam, HIMAGELISTparam, HINSTANCEparam,
-       HKEYparam, HMODULEparam, HPENparam, HRGNparam, HRSRCparam
-       to retrieve and cast handle parameters in functions.
-       They work like HWNDparam and HMENUparam macros.
-     + Macro HANDLEpush.
-     + Macros HANDLEret, HBITMAPret, HBRUSHret, HCURSORret, HDCret,
-       HEMFret, HFONTret, HGDIOBJret, HGLOBALret, HICret, HICONret,
-       HIMAGELISTret, HINSTANCEret, HKEYret, HMENUret, HMODULEret,
-       HPENret, HRGNret, HRSRCret to cast and return handles from
-       functions. The work like HWNDret and HMENUret macros.
-     + Macro LRESULTret.
-     + Macros HANDLEstor, HBITMAPstor, HBRUSHstor, HCURSORstor,
-       HDCstor, HEMFstor, HFONTstor, HGDIOBJstor, HGLOBALstor, HICstor,
-       HICONstor, HIMAGELISTstor, HINSTANCEstor, HKEYstor, HMENUstor,
-       HMODULEstor, HPENstor, HRGNstor, HRSRCstor, HWNDstor,
-       HANDLEstor3, HBITMAPstor3, HBRUSHstor3, HCURSORstor3, HDCstor3,
-       HEMFstor3, HFONTstor3, HGDIOBJstor3, HGLOBALstor3, HICstor3,
-       HICONstor3, HIMAGELISTstor3, HINSTANCEstor3, HKEYstor3,
-       HMENUstor3, HMODULEstor3, HPENstor3, HRGNstor3, HRSRCstor3 and
-       HWNDstor3 to cast and store handles into the return stack.
-     * Updated function prototypes.
-     - Commented code.
+  * core\include\oohg.h
+    * Some format.
+    * Macro HB_STORNL2 renamed to HB_STORNL.
+    * Macro HB_STORPTR renamed to HB_STORPTR3.
+    + Macro HB_STORPTR.
+    + Macros HANDLEparam, HBITMAPparam, HBRUSHparam, HCURSORparam,
+      HDCparam, HEMFparam, HFONTparam, HGDIOBJparam, HGLOBALparam,
+      HICparam, HICONparam, HIMAGELISTparam, HINSTANCEparam,
+      HKEYparam, HMODULEparam, HPENparam, HRGNparam, HRSRCparam
+      to retrieve and cast handle parameters in functions.
+      They work like HWNDparam and HMENUparam macros.
+    + Macro HANDLEpush.
+    + Macros HANDLEret, HBITMAPret, HBRUSHret, HCURSORret, HDCret,
+      HEMFret, HFONTret, HGDIOBJret, HGLOBALret, HICret, HICONret,
+      HIMAGELISTret, HINSTANCEret, HKEYret, HMENUret, HMODULEret,
+      HPENret, HRGNret, HRSRCret to cast and return handles from
+      functions. The work like HWNDret and HMENUret macros.
+    + Macro LRESULTret.
+    + Macros HANDLEstor, HBITMAPstor, HBRUSHstor, HCURSORstor,
+      HDCstor, HEMFstor, HFONTstor, HGDIOBJstor, HGLOBALstor, HICstor,
+      HICONstor, HIMAGELISTstor, HINSTANCEstor, HKEYstor, HMENUstor,
+      HMODULEstor, HPENstor, HRGNstor, HRSRCstor, HWNDstor,
+      HANDLEstor3, HBITMAPstor3, HBRUSHstor3, HCURSORstor3, HDCstor3,
+      HEMFstor3, HFONTstor3, HGDIOBJstor3, HGLOBALstor3, HICstor3,
+      HICONstor3, HIMAGELISTstor3, HINSTANCEstor3, HKEYstor3,
+      HMENUstor3, HMODULEstor3, HPENstor3, HRGNstor3, HRSRCstor3 and
+      HWNDstor3 to cast and store handles into the return stack.
+    * Updated function prototypes.
+    - Commented code.
 
 2020-05-29 20:33 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     * Macro HRGNstor2 renamed to HRGNstor.
+  * core\source\bostaurus.prg
+    * Macro HRGNstor2 renamed to HRGNstor.
 
 2020-05-29 20:31 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_activex.c
-     * Macro HANDLEstor2 renamed to HANDLEstor.
+  * core\source\c_activex.c
+    * Macro HANDLEstor2 renamed to HANDLEstor.
 
 2020-05-29 20:24 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_windows.c
-     * Macro HB_STORPTR renamed to HB_STORPTR3.
+  * core\source\c_windows.c
+    * Macro HB_STORPTR renamed to HB_STORPTR3.
 
 2020-05-29 20:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_registry.prg
-     * Macro HB_STORNL2 renamed to HB_STORNL.
-     * Macro HKEYstor2 renamed to HKEYstor.
+  * core\source\h_registry.prg
+    * Macro HB_STORNL2 renamed to HB_STORNL.
+    * Macro HKEYstor2 renamed to HKEYstor.
 
 2020-05-29 18:18 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-05-29 18:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_windows.c
-     * Use new macros to return values without explicity casting
-       them to LONG_PTR.
+  * core\source\c_windows.c
+    * Use new macros to return values without explicity casting
+      them to LONG_PTR.
 
 2020-05-29 18:15 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-   * core\source\c_activex.c
-   * core\source\c_controlmisc.c
-   * core\source\c_cursor.c
-   * core\source\c_dialogs.c
-   * core\source\c_font.c
-   * core\source\c_graph.c
-   * core\source\c_winapimisc.c
-   * core\source\h_controlmisc.prg
-   * core\source\h_form.prg
-   * core\source\h_menu.prg
-   * core\source\h_registry.prg
-   * core\source\h_tree.prg
-   * core\source\h_windows.prg
-     * Use new macros to return values without explicity casting
-       them to LONG_PTR.
+  * core\source\bostaurus.prg
+  * core\source\c_activex.c
+  * core\source\c_controlmisc.c
+  * core\source\c_cursor.c
+  * core\source\c_dialogs.c
+  * core\source\c_font.c
+  * core\source\c_graph.c
+  * core\source\c_winapimisc.c
+  * core\source\h_controlmisc.prg
+  * core\source\h_form.prg
+  * core\source\h_menu.prg
+  * core\source\h_registry.prg
+  * core\source\h_tree.prg
+  * core\source\h_windows.prg
+    * Use new macros to return values without explicity casting
+      them to LONG_PTR.
 
 2020-05-29 17:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_cursor.prg
-     * Some format.
+  * core\source\h_cursor.prg
+    * Some format.
 
 2020-05-29 17:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_dll.prg
-     - EXTERN declaration.
-     * Functions were reorderer to avoid prototypes.
-     * Var HB_DllStore renamed to _OOHG_DllStore.
-     * Function HB_UnloadDll renamed to _OOHG_UnloadDll.
-       INCOMPATIBLE.
-     * Function HB_DllStore renamed to _OOHG_DllStore.
-     * Some format.
-     * Use new macros to return values without explicity casting
-       them to LONG_PTR.
+  * core\source\h_dll.prg
+    - EXTERN declaration.
+    * Functions were reorderer to avoid prototypes.
+    * Var HB_DllStore renamed to _OOHG_DllStore.
+    * Function HB_UnloadDll renamed to _OOHG_UnloadDll.
+      INCOMPATIBLE.
+    * Function HB_DllStore renamed to _OOHG_DllStore.
+    * Some format.
+    * Use new macros to return values without explicity casting
+      them to LONG_PTR.
 
 2020-05-29 17:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_notify.prg
-     ! Function's name casing.
+  * core\source\h_notify.prg
+    ! Function's name casing.
 
 2020-05-29 17:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_richeditbox.prg
-     + Some commented code for future implementation.
+  * core\source\h_richeditbox.prg
+    + Some commented code for future implementation.
 
 2020-05-29 17:05 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-     * Use new macros to return values without explicity casting
-       them to LONG_PTR.
+  * core\source\miniprint.prg
+    * Use new macros to return values without explicity casting
+      them to LONG_PTR.
 
 2020-05-29 17:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     * Some format and casting.
-     + Support for bitmaps and DIBs when creating brushes.
-     * Use new macros to return values without explicity casting
-       them to LONG_PTR.
+  * core\source\winprint.prg
+    * Some format and casting.
+    + Support for bitmaps and DIBs when creating brushes.
+    * Use new macros to return values without explicity casting
+      them to LONG_PTR.
 
 2020-05-27 16:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_activex.c
-     * Some format.
-     - Unneeded includes.
-     - Commented code.
-     * Calls to function GetProcAddress were replaced by a call to
-       function _OOHG_GetProcAddress to pacify MinGW warning.
-     + Comment indicating the right order of the #include.
-     + Comment indicating that this code must be compiled as a
-       standalone module.
+  * core\source\c_activex.c
+    * Some format.
+    - Unneeded includes.
+    - Commented code.
+    * Calls to function GetProcAddress were replaced by a call to
+      function _OOHG_GetProcAddress to pacify MinGW warning.
+    + Comment indicating the right order of the #include.
+    + Comment indicating that this code must be compiled as a
+      standalone module.
 
 2020-05-27 16:12 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_graph.c
-     * Some format.
+  * core\source\c_graph.c
+    * Some format.
 
 2020-05-27 16:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_activex.prg
-     * Some format.
-     - Commented out code.
+  * core\source\h_activex.prg
+    * Some format.
+    - Commented out code.
 
 2020-05-27 15:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     * Some format.
+  * core\source\h_print.prg
+    * Some format.
 
 2020-05-26 23:35 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_controlmisc.c
-   * core\source\c_cursor.c
-   * core\source\c_graph.c
-   * core\source\c_image.c
-   * core\source\c_scrsaver.c
-   * core\source\c_winapimisc.c
-   * core\source\h_anigif.prg
-   * core\source\h_grid.prg
-   * core\source\h_ini.prg
-   * core\source\h_picture.prg
-   * core\source\h_print.prg
-   * core\source\h_progressbar.prg
-   * core\source\h_progressmeter.prg
-   * core\source\h_registry.prg
-   * core\source\h_richeditbox.prg
-   * core\source\h_splitbox.prg
-   * core\source\h_status.prg
-   * core\source\h_textarray.prg
-   * core\source\h_toolbar.prg
-   * core\source\h_miniprint.prg
-   * core\source\h_winprint.prg
-     * Some format.
+  * core\source\c_controlmisc.c
+  * core\source\c_cursor.c
+  * core\source\c_graph.c
+  * core\source\c_image.c
+  * core\source\c_scrsaver.c
+  * core\source\c_winapimisc.c
+  * core\source\h_anigif.prg
+  * core\source\h_grid.prg
+  * core\source\h_ini.prg
+  * core\source\h_picture.prg
+  * core\source\h_print.prg
+  * core\source\h_progressbar.prg
+  * core\source\h_progressmeter.prg
+  * core\source\h_registry.prg
+  * core\source\h_richeditbox.prg
+  * core\source\h_splitbox.prg
+  * core\source\h_status.prg
+  * core\source\h_textarray.prg
+  * core\source\h_toolbar.prg
+  * core\source\h_miniprint.prg
+  * core\source\h_winprint.prg
+    * Some format.
 
 2020-05-26 23:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-05-26 23:27 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.hbp
-   * core\source\hbprinter.hbp
-   * core\source\miniprint.hbp
-   * core\source\oohg.hbp
-     * Some warnings are now set by default, others removed.
+  * core\source\bostaurus.hbp
+  * core\source\hbprinter.hbp
+  * core\source\miniprint.hbp
+  * core\source\oohg.hbp
+    * Some warnings are now set by default, others removed.
 
 2020-05-26 23:09 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_gdiplus.c
-     * Changed some format and casting.
-     * Calls to function GetProcAddress were replaced by a call to
-       function _OOHG_GetProcAddress to pacify MinGW warning.
-     ! Return value of function GPlusLoadImageFromBuffer.
+  * core\source\c_gdiplus.c
+    * Changed some format and casting.
+    * Calls to function GetProcAddress were replaced by a call to
+      function _OOHG_GetProcAddress to pacify MinGW warning.
+    ! Return value of function GPlusLoadImageFromBuffer.
 
 2020-05-26 22:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_controlmisc.c
-     * Changed some format and casting.
-     * Changed type of function _OOHG_DoEvent third parameter
-       to const char *.
-     * Changed type of function _OOHG_DoEventMouseCoords third
-       parameter to const char *.
-     ! Functions GetProgramFilename and GetModuleFilename when
-       the length of filename equals MAX_PATH.
+  * core\source\c_controlmisc.c
+    * Changed some format and casting.
+    * Changed type of function _OOHG_DoEvent third parameter
+      to const char *.
+    * Changed type of function _OOHG_DoEventMouseCoords third
+      parameter to const char *.
+    ! Functions GetProgramFilename and GetModuleFilename when
+      the length of filename equals MAX_PATH.
 
 2020-05-26 21:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_graph.c
-     * Changed some format and casting.
+  * core\source\c_graph.c
+    * Changed some format and casting.
 
 2020-05-26 21:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_image.c
-     * Changed some format and casting.
-     * Changed type of function _OOHG_LoadImage first parameter
-       to const char *.
+  * core\source\c_image.c
+    * Changed some format and casting.
+    * Changed type of function _OOHG_LoadImage first parameter
+      to const char *.
 
 2020-05-26 19:18 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_msgbox.c
-     * Changed some format and casting.
-     ! Wrong casting of handle at function MessageBoxIndirect.
+  * core\source\c_msgbox.c
+    * Changed some format and casting.
+    ! Wrong casting of handle at function MessageBoxIndirect.
 
 2020-05-26 18:36 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_scrsaver.c
-     * Changed some format and casting.
-     * Call to function GetProcAddress was replaced by a call to
-       function _OOHG_GetProcAddress to pacify MinGW warning.
+  * core\source\c_scrsaver.c
+    * Changed some format and casting.
+    * Call to function GetProcAddress was replaced by a call to
+      function _OOHG_GetProcAddress to pacify MinGW warning.
 
 2020-05-26 18:31 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     * Changed some format and casting.
-     * Call to function GetProcAddress was replaced by a call to
-       function _OOHG_GetProcAddress to pacify MinGW warning.
-     + Function _OOHG_GetProcAddress to retrieve a FARPROC pointer
-       from GetProcAddress and cast it to HB_PRTUINT.
+  * core\source\c_winapimisc.c
+    * Changed some format and casting.
+    * Call to function GetProcAddress was replaced by a call to
+      function _OOHG_GetProcAddress to pacify MinGW warning.
+    + Function _OOHG_GetProcAddress to retrieve a FARPROC pointer
+      from GetProcAddress and cast it to HB_PRTUINT.
 
 2020-05-26 18:12 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_font.c
-     * Changed some format and casting.
+  * core\source\c_font.c
+    * Changed some format and casting.
 
 2020-05-26 18:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostarurus.prg
-     * Some format.
-     + Mutex protection to a static var.
-     * A static var is now local.
-     * Call to function GetProcAddress was replaced by a call to
-       function _OOHG_GetProcAddress to pacify MinGW warning.
+  * core\source\bostarurus.prg
+    * Some format.
+    + Mutex protection to a static var.
+    * A static var is now local.
+    * Call to function GetProcAddress was replaced by a call to
+      function _OOHG_GetProcAddress to pacify MinGW warning.
 
 2020-05-26 17:54 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_font.c
-     * Changed some format and casting.
+  * core\source\c_font.c
+    * Changed some format and casting.
 
 2020-05-26 17:52 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_button.prg
-     + Function prototype.
+  * core\source\h_button.prg
+    + Function prototype.
 
 2020-05-26 17:51 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_controlmisc.prg
-     + Function prototype.
+  * core\source\h_controlmisc.prg
+    + Function prototype.
 
 2020-05-26 17:51 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     * Changed some casting.
+  * core\source\h_form.prg
+    * Changed some casting.
 
 2020-05-26 17:50 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_menu.prg
-     + Function prototype.
+  * core\source\h_menu.prg
+    + Function prototype.
 
 2020-05-26 17:49 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_tree.prg
-     + Function prototype.
+  * core\source\h_tree.prg
+    + Function prototype.
 
 2020-05-26 17:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     * Changed some casting.
+  * core\source\winprint.prg
+    * Changed some casting.
 
 2020-05-25 22:51 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_cursor.c
-     * Some format.
-     ! Typo.
+  * core\source\c_cursor.c
+    * Some format.
+    ! Typo.
 
 2020-05-25 22:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     * Change some casting.
-     ! Typo.
+  * core\source\bostaurus.prg
+    * Change some casting.
+    ! Typo.
 
 2020-05-25 22:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\bostaurus.ch
-     ! Typo.
+  * core\include\bostaurus.ch
+    ! Typo.
 
 2020-05-25 22:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\hmg.ch
-   * core\include\i_activex.ch
-   * core\include\i_altsyntax.ch
-   * core\include\i_anigif.ch
-   * core\include\i_app.ch
-   * core\include\i_browse.ch
-   * core\include\i_button.ch
-   * core\include\i_checkbox.ch
-   * core\include\i_checklist.ch
-   * core\include\i_color.ch
-   * core\include\i_combobox.ch
-   * core\include\i_comm.ch
-   * core\include\i_controlmisc.ch
-   * core\include\i_datepicker.ch
-   * core\include\i_edit.ch
-   * core\include\i_editbox.ch
-   * core\include\i_encrypt.ch
-   * core\include\i_exec.ch
-   * core\include\i_font.ch
-   * core\include\i_frame.ch
-   * core\include\i_graph.ch
-   * core\include\i_grid.ch
-   * core\include\i_hb_compat.ch
-   * core\include\i_help.ch
-   * core\include\i_hmg_compat.ch
-   * core\include\i_hotkeybox.ch
-   * core\include\i_hyperlink.ch
-   * core\include\i_image.ch
-   * core\include\i_ini.ch
-   * core\include\i_init.ch
-   * core\include\i_internal.ch
-   * core\include\i_ipaddress.ch
-   * core\include\i_keybd.ch
-   * core\include\i_label.ch
-   * core\include\i_lang.ch
-   * core\include\i_listbox.ch
-   * core\include\i_media.ch
-   * core\include\i_menu.ch
-   * core\include\i_misc.ch
-   * core\include\i_monthcal.ch
-   * core\include\i_picture.ch
-   * core\include\i_progressbar.ch
-   * core\include\i_progressmeter.ch
-   * core\include\i_pseudofunc.ch
-   * core\include\i_radiogroup.ch
-   * core\include\i_region.ch
-   * core\include\i_registry.ch
-   * core\include\i_report.ch
-   * core\include\i_scroll.ch
-   * core\include\i_scrsaver.ch
-   * core\include\i_slider.ch
-   * core\include\i_spinner.ch
-   * core\include\i_splitbox.ch
-   * core\include\i_status.ch
-   * core\include\i_tab.ch
-   * core\include\i_textarray.ch
-   * core\include\i_textboxbox.ch
-   * core\include\i_this.ch
-   * core\include\i_timer.ch
-   * core\include\i_toolbar.ch
-   * core\include\i_tooltip.ch
-   * core\include\i_tree.ch
-   * core\include\i_var.ch
-   * core\include\i_windef.ch
-   * core\include\i_window.ch
-   * core\include\i_xbrowse.ch
-   * core\include\i_zip.ch
-   * core\include\menu.h
-   * core\include\minigui.ch
-   * core\include\miniprint.ch
-   * core\include\oohg.ch
-   * core\include\oohgversion.h
-   * core\include\winprint.ch
-   * core\oohg_license_template.txt
-   * core\source\c_dialogs.c
-   * core\source\c_media.c
-   * core\source\c_resource.c
-     ! Typo.
+  * core\include\hmg.ch
+  * core\include\i_activex.ch
+  * core\include\i_altsyntax.ch
+  * core\include\i_anigif.ch
+  * core\include\i_app.ch
+  * core\include\i_browse.ch
+  * core\include\i_button.ch
+  * core\include\i_checkbox.ch
+  * core\include\i_checklist.ch
+  * core\include\i_color.ch
+  * core\include\i_combobox.ch
+  * core\include\i_comm.ch
+  * core\include\i_controlmisc.ch
+  * core\include\i_datepicker.ch
+  * core\include\i_edit.ch
+  * core\include\i_editbox.ch
+  * core\include\i_encrypt.ch
+  * core\include\i_exec.ch
+  * core\include\i_font.ch
+  * core\include\i_frame.ch
+  * core\include\i_graph.ch
+  * core\include\i_grid.ch
+  * core\include\i_hb_compat.ch
+  * core\include\i_help.ch
+  * core\include\i_hmg_compat.ch
+  * core\include\i_hotkeybox.ch
+  * core\include\i_hyperlink.ch
+  * core\include\i_image.ch
+  * core\include\i_ini.ch
+  * core\include\i_init.ch
+  * core\include\i_internal.ch
+  * core\include\i_ipaddress.ch
+  * core\include\i_keybd.ch
+  * core\include\i_label.ch
+  * core\include\i_lang.ch
+  * core\include\i_listbox.ch
+  * core\include\i_media.ch
+  * core\include\i_menu.ch
+  * core\include\i_misc.ch
+  * core\include\i_monthcal.ch
+  * core\include\i_picture.ch
+  * core\include\i_progressbar.ch
+  * core\include\i_progressmeter.ch
+  * core\include\i_pseudofunc.ch
+  * core\include\i_radiogroup.ch
+  * core\include\i_region.ch
+  * core\include\i_registry.ch
+  * core\include\i_report.ch
+  * core\include\i_scroll.ch
+  * core\include\i_scrsaver.ch
+  * core\include\i_slider.ch
+  * core\include\i_spinner.ch
+  * core\include\i_splitbox.ch
+  * core\include\i_status.ch
+  * core\include\i_tab.ch
+  * core\include\i_textarray.ch
+  * core\include\i_textboxbox.ch
+  * core\include\i_this.ch
+  * core\include\i_timer.ch
+  * core\include\i_toolbar.ch
+  * core\include\i_tooltip.ch
+  * core\include\i_tree.ch
+  * core\include\i_var.ch
+  * core\include\i_windef.ch
+  * core\include\i_window.ch
+  * core\include\i_xbrowse.ch
+  * core\include\i_zip.ch
+  * core\include\menu.h
+  * core\include\minigui.ch
+  * core\include\miniprint.ch
+  * core\include\oohg.ch
+  * core\include\oohgversion.h
+  * core\include\winprint.ch
+  * core\oohg_license_template.txt
+  * core\source\c_dialogs.c
+  * core\source\c_media.c
+  * core\source\c_resource.c
+    ! Typo.
 
 2020-05-25 22:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_dll.ch
-     * Function CallDll32 was renamed as _OOHG_CallDll32 to avoid
-       clashing with Harbour's CallDll32 function in HBMISC lib.
-       INCOMPATIBLE.
+  * core\include\i_dll.ch
+    * Function CallDll32 was renamed as _OOHG_CallDll32 to avoid
+      clashing with Harbour's CallDll32 function in HBMISC lib.
+      INCOMPATIBLE.
 
 2020-05-25 22:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_activex.prg
-   * core\source\h_anigif.prg
-   * core\source\h_application.prg
-   * core\source\h_browse.prg
-   * core\source\h_button.prg
-   * core\source\h_checkbox.prg
-   * core\source\h_checklist.prg
-   * core\source\h_combo.prg
-   * core\source\h_comm.prg
-   * core\source\h_crypt.prg
-   * core\source\h_cursor.prg
-   * core\source\h_datepicker.prg
-   * core\source\h_dialogs.prg
-   * core\source\h_edit.prg
-   * core\source\h_edit_ex.prg
-   * core\source\h_editbox.prg
-   * core\source\h_error.prg
-   * core\source\h_frame.prg
-   * core\source\h_graph.prg
-   * core\source\h_help.prg
-   * core\source\h_hotkey.prg
-   * core\source\h_hotkeybox.prg
-   * core\source\h_hyperlink.prg
-   * core\source\h_image.prg
-   * core\source\h_ini.prg
-   * core\source\h_init.prg
-   * core\source\h_internal.prg
-   * core\source\h_ipaddress.prg
-   * core\source\h_label.prg
-   * core\source\h_listbox.prg
-   * core\source\h_monthcal.prg
-   * core\source\h_msgbox.prg
-   * core\source\h_pdf.prg
-   * core\source\h_picture.prg
-   * core\source\h_print.prg
-   * core\source\h_progressmeter.prg
-   * core\source\h_radio.prg
-   * core\source\h_report.prg
-   * core\source\h_richeditbox.prg
-   * core\source\h_scroll.prg
-   * core\source\h_scrollbutton.prg
-   * core\source\h_scrsaver.prg
-   * core\source\h_slider.prg
-   * core\source\h_spinner.prg
-   * core\source\h_splitbox.prg
-   * core\source\h_status.prg
-   * core\source\h_tab.prg
-   * core\source\h_textarray.prg
-   * core\source\h_textbox.prg
-   * core\source\h_timer.prg
-   * core\source\h_tooltip.prg
-   * core\source\h_winapimisc.prg
-   * core\source\h_windows.prg
-   * core\source\h_xbrowse.prg
-   * core\source\miniprint.prg
-   * core\source\winprint.prg
-     ! Typo.
+  * core\source\h_activex.prg
+  * core\source\h_anigif.prg
+  * core\source\h_application.prg
+  * core\source\h_browse.prg
+  * core\source\h_button.prg
+  * core\source\h_checkbox.prg
+  * core\source\h_checklist.prg
+  * core\source\h_combo.prg
+  * core\source\h_comm.prg
+  * core\source\h_crypt.prg
+  * core\source\h_cursor.prg
+  * core\source\h_datepicker.prg
+  * core\source\h_dialogs.prg
+  * core\source\h_edit.prg
+  * core\source\h_edit_ex.prg
+  * core\source\h_editbox.prg
+  * core\source\h_error.prg
+  * core\source\h_frame.prg
+  * core\source\h_graph.prg
+  * core\source\h_help.prg
+  * core\source\h_hotkey.prg
+  * core\source\h_hotkeybox.prg
+  * core\source\h_hyperlink.prg
+  * core\source\h_image.prg
+  * core\source\h_ini.prg
+  * core\source\h_init.prg
+  * core\source\h_internal.prg
+  * core\source\h_ipaddress.prg
+  * core\source\h_label.prg
+  * core\source\h_listbox.prg
+  * core\source\h_monthcal.prg
+  * core\source\h_msgbox.prg
+  * core\source\h_pdf.prg
+  * core\source\h_picture.prg
+  * core\source\h_print.prg
+  * core\source\h_progressmeter.prg
+  * core\source\h_radio.prg
+  * core\source\h_report.prg
+  * core\source\h_richeditbox.prg
+  * core\source\h_scroll.prg
+  * core\source\h_scrollbutton.prg
+  * core\source\h_scrsaver.prg
+  * core\source\h_slider.prg
+  * core\source\h_spinner.prg
+  * core\source\h_splitbox.prg
+  * core\source\h_status.prg
+  * core\source\h_tab.prg
+  * core\source\h_textarray.prg
+  * core\source\h_textbox.prg
+  * core\source\h_timer.prg
+  * core\source\h_tooltip.prg
+  * core\source\h_winapimisc.prg
+  * core\source\h_windows.prg
+  * core\source\h_xbrowse.prg
+  * core\source\miniprint.prg
+  * core\source\winprint.prg
+    ! Typo.
 
 2020-05-25 22:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     ! Wrong type of function _OOHG_SortItemsUser.
+  * core\source\h_grid.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    ! Wrong type of function _OOHG_SortItemsUser.
 
 2020-05-25 19:19 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_controlmisc.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     ! Wrong casting of handle at method Events of class TControl.
-     ! Wrong casting of handle at method Events_Color of class TControl.
-     ! Type of function _OOHG_SortItems.
+  * core\source\h_controlmisc.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    ! Wrong casting of handle at method Events of class TControl.
+    ! Wrong casting of handle at method Events_Color of class TControl.
+    ! Type of function _OOHG_SortItems.
 
 2020-05-25 19:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_dll.prg
-     * Some format.
-     * Type of dynamic calls parameters changed from INT to LONG_PTR.
-     * Type of dynamic calls return value changed from INT to LONG_PTR.
-     * Function CallDll32 was renamed as _OOHG_CallDll32 to avoid
-       clashing with Harbour's CallDll32 function in HBMISC lib.
-       INCOMPATIBLE.
+  * core\source\h_dll.prg
+    * Some format.
+    * Type of dynamic calls parameters changed from INT to LONG_PTR.
+    * Type of dynamic calls return value changed from INT to LONG_PTR.
+    * Function CallDll32 was renamed as _OOHG_CallDll32 to avoid
+      clashing with Harbour's CallDll32 function in HBMISC lib.
+      INCOMPATIBLE.
 
 2020-05-25 19:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     * Type of function _OOHG_AdjustSize was changed from int to BOOL.
+  * core\source\h_form.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    * Type of function _OOHG_AdjustSize was changed from int to BOOL.
 
 2020-05-25 18:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_media.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_media.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-25 18:53 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_menu.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_menu.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-25 18:37 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_notify.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     ! Wrong casting of handle at function LoadTrayIcon.
+  * core\source\h_notify.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    ! Wrong casting of handle at function LoadTrayIcon.
 
 2020-05-25 18:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_registry.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     * Call to function GetProcAddress was replaced by a call to
-       function _OOHG_GetProcAddress to pacify MinGW warning.
+  * core\source\h_registry.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    * Call to function GetProcAddress was replaced by a call to
+      function _OOHG_GetProcAddress to pacify MinGW warning.
 
 2020-05-25 17:01 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_tree.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_tree.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-25 14:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_controlmisc.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     ! Wrong casting of handle at method Events of class TControl.
+  * core\source\h_controlmisc.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    ! Wrong casting of handle at method Events of class TControl.
 
 2020-05-25 14:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_combobox.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_combobox.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:52 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_resource.c
-     * Some format.
+  * core\source\c_resource.c
+    * Some format.
 
 2020-05-24 22:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_media.c
-     * Some format.
+  * core\source\c_media.c
+    * Some format.
 
 2020-05-24 22:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_dialogs.c
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\c_dialogs.c
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:39 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_anigif.prg
-     * Some format.
+  * core\source\h_anigif.prg
+    * Some format.
 
 2020-05-24 22:38 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_application.prg
-     * Some format.
+  * core\source\h_application.prg
+    * Some format.
 
 2020-05-24 22:37 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_browse.prg
-     * Some format.
+  * core\source\h_browse.prg
+    * Some format.
 
 2020-05-24 22:36 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_button.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_button.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:34 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_checkbox.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_checkbox.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:33 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_checklist.prg
-     * Some format.
+  * core\source\h_checklist.prg
+    * Some format.
 
 2020-05-24 22:31 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_crypt.prg
-     * Some format.
+  * core\source\h_crypt.prg
+    * Some format.
 
 2020-05-24 22:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_datepicker.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_datepicker.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_frame.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_frame.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_help.prg
-     * Some format.
+  * core\source\h_help.prg
+    * Some format.
 
 2020-05-24 22:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_hotkey.prg
-     * Some format.
+  * core\source\h_hotkey.prg
+    * Some format.
 
 2020-05-24 22:24 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_hotkeybox.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_hotkeybox.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:23 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_internal.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_internal.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_ipaddress.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_ipaddress.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_listbox.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_listbox.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:20 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_image.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_image.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:18 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_ini.prg
-     * Some format.
+  * core\source\h_ini.prg
+    * Some format.
 
 2020-05-24 22:17 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     * Some format.
+  * core\source\h_init.prg
+    * Some format.
 
 2020-05-24 22:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_label.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_label.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_monthcal.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     ! Wrong casting of pointers at functions GetViewChangeData,
-       C_RetDayState and GetDayStateData.
+  * core\source\h_monthcal.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    ! Wrong casting of pointers at functions GetViewChangeData,
+      C_RetDayState and GetDayStateData.
 
 2020-05-24 22:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_pdf.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_pdf.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:04 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_picture.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_picture.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 22:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_progressbar.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_progressbar.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:59 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_progressmeter.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_progressmeter.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_radio.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_radio.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_richeditbox.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     ! Wrong casting of handle at function FileStreamOut.
+  * core\source\h_richeditbox.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    ! Wrong casting of handle at function FileStreamOut.
 
 2020-05-24 21:51 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_scroll.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_scroll.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:50 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_scrollbutton.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_scrollbutton.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:50 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_spinner.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_spinner.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:49 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_slider.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_slider.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:47 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_splitbox.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_splitbox.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:45 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_status.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_status.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:38 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_tab.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_tab.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:37 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_textarray.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_textarray.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:35 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_textbox.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_textbox.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_toolbar.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
+  * core\source\h_toolbar.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
 
 2020-05-24 21:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_tooltip.prg
-     * Some format.
-     * Some casting and some parameter's type to pacify C compiler.
-     ! Wrong casting of HWND at functions SetToolTip and GetToolTip.
-     * Added mutex to protect tooltip's buffer.
+  * core\source\h_tooltip.prg
+    * Some format.
+    * Some casting and some parameter's type to pacify C compiler.
+    ! Wrong casting of HWND at functions SetToolTip and GetToolTip.
+    * Added mutex to protect tooltip's buffer.
 
 2020-05-24 20:59 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     * Some format.
-     * Some casting to pacify C compiler.
+  * core\source\h_windows.prg
+    * Some format.
+    * Some casting to pacify C compiler.
 
 2020-05-24 20:51 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     * Some format.
+  * core\source\h_xbrowse.prg
+    * Some format.
 
 2020-05-24 20:47 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-     * Some format.
+  * core\source\miniprint.prg
+    * Some format.
 
 2020-05-24 20:14 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.hbp
-     + More warnings to C compilation.
-     * Warnings can be enabled defining envvar HG_CFLAGS.
+  * core\source\bostaurus.hbp
+    + More warnings to C compilation.
+    * Warnings can be enabled defining envvar HG_CFLAGS.
 
 2020-05-24 11:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.hbp
-   * core\source\miniprint.hbp
-   * core\source\winprint.hbp
-   * core\source\oohg.hbp
-     + More warnings to C compilation.
-     * Warnings can be enabled defining envvar HG_CFLAGS.
+  * core\source\bostaurus.hbp
+  * core\source\miniprint.hbp
+  * core\source\winprint.hbp
+  * core\source\oohg.hbp
+    + More warnings to C compilation.
+    * Warnings can be enabled defining envvar HG_CFLAGS.
 
 2020-05-24 11:24 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     * Some casting to pacify C compiler.
+  * core\source\winprint.prg
+    * Some casting to pacify C compiler.
 
 2020-05-23 13:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_textarray.prg
-     * Some format.
-     * Some changes to pacify warnings from C compiler.
+  * core\source\h_textarray.prg
+    * Some format.
+    * Some changes to pacify warnings from C compiler.
 
 2020-05-23 13:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_timer.prg
-     * Some format.
+  * core\source\h_timer.prg
+    * Some format.
 
 2020-05-23 13:20 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     * Some format.
+  * core\source\winprint.prg
+    * Some format.
 
 2020-05-19 20:19 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_pseudofunc.ch
-     * Added a space to OOHG_Version() return value.
+  * core\include\i_pseudofunc.ch
+    * Added a space to OOHG_Version() return value.
 
 2020-05-19 19:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\buildapp.bat
-   + core\BuildApp3264.bat
-   + core\BuildApp3464.bat
-   * core\compile.bat
-   + core\compile3264.bat
-   + core\compile3464.bat
-   * core\resources\CompileRes.bat
-   * core\resources\CompileRes_mingw.bat
-   * core\source\BuildLib.bat
-   + core\source\BuildLib3264.bat
-   + core\source\BuildLib3464.bat
-   * core\source\makelib.bat
-   + core\source\makelib3264.bat
-   + core\source\makelib3464.bat
-     * Added support for 2 new flavor: HM3264 and HM3464.
+  * core\buildapp.bat
+  + core\BuildApp3264.bat
+  + core\BuildApp3464.bat
+  * core\compile.bat
+  + core\compile3264.bat
+  + core\compile3464.bat
+  * core\resources\CompileRes.bat
+  * core\resources\CompileRes_mingw.bat
+  * core\source\BuildLib.bat
+  + core\source\BuildLib3264.bat
+  + core\source\BuildLib3464.bat
+  * core\source\makelib.bat
+  + core\source\makelib3264.bat
+  + core\source\makelib3464.bat
+  * Added support for 2 new flavor: HM3264 and HM3464.
 
 2020-05-18 09:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_winprint.prg
-     * Some changes for 64 bits support.
+  * core\source\h_winprint.prg
+    * Some changes for 64 bits support.
 
 2020-05-16 08:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_windows.c
-   * core\source\h_button.prg
-   * core\source\h_checkbox.prg
-   * core\source\h_combo.prg
-   * core\source\h_datepicker.prg
-   * core\source\h_form.prg
-   * core\source\h_frame.prg
-   * core\source\h_grid.prg
-   * core\source\h_hotkeybox.prg
-   * core\source\h_image.prg
-   * core\source\h_internal.prg
-   * core\source\h_ipaddress.prg
-   * core\source\h_label.prg
-   * core\source\h_listbox.prg
-   * core\source\h_monthcal.prg
-   * core\source\h_picture.prg
-   * core\source\h_progressbar.prg
-   * core\source\h_radio.prg
-   * core\source\h_richeditbox.prg
-   * core\source\h_scroll.prg
-   * core\source\h_scrollbutton.prg
-   * core\source\h_slider.prg
-   * core\source\h_spinner.prg
-   * core\source\h_splitbox.prg
-   * core\source\h_status.prg
-   * core\source\h_tab.prg
-   * core\source\h_textarray.prg
-   * core\source\h_textbox.prg
-   * core\source\h_toolbar.prg
-   * core\source\h_tooltip.prg
-   * core\source\h_tree.prg
-     * Some changes for 64 bits support.
+  * core\source\c_windows.c
+  * core\source\h_button.prg
+  * core\source\h_checkbox.prg
+  * core\source\h_combo.prg
+  * core\source\h_datepicker.prg
+  * core\source\h_form.prg
+  * core\source\h_frame.prg
+  * core\source\h_grid.prg
+  * core\source\h_hotkeybox.prg
+  * core\source\h_image.prg
+  * core\source\h_internal.prg
+  * core\source\h_ipaddress.prg
+  * core\source\h_label.prg
+  * core\source\h_listbox.prg
+  * core\source\h_monthcal.prg
+  * core\source\h_picture.prg
+  * core\source\h_progressbar.prg
+  * core\source\h_radio.prg
+  * core\source\h_richeditbox.prg
+  * core\source\h_scroll.prg
+  * core\source\h_scrollbutton.prg
+  * core\source\h_slider.prg
+  * core\source\h_spinner.prg
+  * core\source\h_splitbox.prg
+  * core\source\h_status.prg
+  * core\source\h_tab.prg
+  * core\source\h_textarray.prg
+  * core\source\h_textbox.prg
+  * core\source\h_toolbar.prg
+  * core\source\h_tooltip.prg
+  * core\source\h_tree.prg
+    * Some changes for 64 bits support.
 
 2020-05-15 19:45 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     ! Function _OOHG_MacroCall generates RTE when called.
-     - Static function _OOHG_MacroCall_Error.
+  * core\source\h_windows.prg
+    ! Function _OOHG_MacroCall generates RTE when called.
+    - Static function _OOHG_MacroCall_Error.
 
 2020-05-15 19:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     - Data Name.
-     + Data cName.
-     + Method Name.
-     ; This method ignores any attempt of renaming the object.
-       It's a workaround to avoid an RTE while correct renaming
-       is not implemented.
+  * core\source\h_windows.prg
+    - Data Name.
+    + Data cName.
+    + Method Name.
+    ; This method ignores any attempt of renaming the object.
+      It's a workaround to avoid an RTE while correct renaming
+      is not implemented.
 
 2020-05-15 19:23 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-05-15 17:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     ! Typo at method AddColumn that prevents compilation.
+  * core\source\h_xbrowse.prg
+    ! Typo at method AddColumn that prevents compilation.
 
 2020-05-15 16:34 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! Header doubleclick and header color support at method
-       AddColumn of TGridByCell class.
+  * core\source\h_grid.prg
+    ! Header doubleclick and header color support at method
+      AddColumn of TGridByCell class.
 
 2020-05-15 16:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     ! Header color support at method AddColumn.
+  * core\source\h_xbrowse.prg
+    ! Header color support at method AddColumn.
 
 2020-05-15 16:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_browse.prg
-     ! Header color support at method AddColumn.
+  * core\source\h_browse.prg
+    ! Header color support at method AddColumn.
 
 2020-05-15 00:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2020-05-15 00:05 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_bcc.bat
-     + Include folder for proper resource compilation.
+  * core\compile_bcc.bat
+    + Include folder for proper resource compilation.
 
 2020-05-15 00:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_MINGW.BAT
-     + #include "oohgversion.h"
+  * core\compile_MINGW.BAT
+    + #include "oohgversion.h"
 
 C:\GitOOHG\core\compile_MINGW.BAT
 2020-05-15 00:02 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\BuildApp_hbmk2.bat
-     + #include "oohgversion.h"
+  * core\BuildApp_hbmk2.bat
+    + #include "oohgversion.h"
 
 2020-05-15 00:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\resources\_oohg_resconfig.h
-     + #include "oohgversion.h"
+  * core\resources\_oohg_resconfig.h
+    + #include "oohgversion.h"
 
 2020-05-14 23:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\resources\CompileRes_bcc.bat
-     + Include folder for proper resource compilation.
+  * core\resources\CompileRes_bcc.bat
+    + Include folder for proper resource compilation.
 
 2020-05-14 23:54 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\resources\oohg_bcc.rc
-     + #include "oohgversion.h"
-     + Comments with HBPRINTER and MINIPRINT string tables.
+  * core\resources\oohg_bcc.rc
+    + #include "oohgversion.h"
+    + Comments with HBPRINTER and MINIPRINT string tables.
 
 2020-05-14 23:50 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_dialogs.prg
-     * Function GetColor:
-       + Second parameter uCustomColors: an array of 16 colors
-         to fill the custom color boxes of the dialog. Each item
-         must be a COLORREF (number) or and RGB array. Invalid
-         items will default to -1 (COLOR_BTNFACE). Any change
-         made by the user in the dialog will be reflected in
-         the array.
+  * core\source\h_dialogs.prg
+    * Function GetColor:
+      + Second parameter uCustomColors: an array of 16 colors
+        to fill the custom color boxes of the dialog. Each item
+        must be a COLORREF (number) or and RGB array. Invalid
+        items will default to -1 (COLOR_BTNFACE). Any change
+        made by the user in the dialog will be reflected in
+        the array.
 
 2020-05-14 23:35 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_winapimisc.prg
-     + Function BmpSize( uImage) where uImage is an HBITMAP or
-       the name of a resource.
+  * core\source\h_winapimisc.prg
+    + Function BmpSize( uImage) where uImage is an HBITMAP or
+      the name of a resource.
 
 2020-05-14 23:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_checklist.prg
-     - Unneeded code.
+  * core\source\h_checklist.prg
+    - Unneeded code.
 
 2020-05-14 23:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_this.ch
-     + Support for Cargo and Cursor properties to This semi-object.
-     + Virtual vars: ThisForm, ThisControl, LastForm, LastControl.
-       They can be used in semioop and in object notation, e.g.
-       ThisForm:Name and ThisForm.Name are both acceptable.
+  * core\include\i_this.ch
+    + Support for Cargo and Cursor properties to This semi-object.
+    + Virtual vars: ThisForm, ThisControl, LastForm, LastControl.
+      They can be used in semioop and in object notation, e.g.
+      ThisForm:Name and ThisForm.Name are both acceptable.
 
 2020-05-14 23:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_var.ch
-     + Pseudo-variable _OOHG_RegisteredControls: returns a clone
-       of OOHG's _OOHG_aControlObjects array.
-     + Pseudo-variable _OOHG_LastDefinedControl: returns the object
-       corresponding to the last defined (the tail item of the
-       _OOHG_aControlObjects array.
+  * core\include\i_var.ch
+    + Pseudo-variable _OOHG_RegisteredControls: returns a clone
+      of OOHG's _OOHG_aControlObjects array.
+    + Pseudo-variable _OOHG_LastDefinedControl: returns the object
+      corresponding to the last defined (the tail item of the
+      _OOHG_aControlObjects array.
 
 2020-05-14 23:15 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     + Function IsExe64 for xHarbour builds.
+  * core\source\c_winapimisc.c
+    + Function IsExe64 for xHarbour builds.
 
 2020-05-14 23:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_windows.c
-     + Function GetDesktopArea: returns {left,top,right,bottom}.
+  * core\source\c_windows.c
+    + Function GetDesktopArea: returns {left,top,right,bottom}.
 
 2020-05-14 23:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_dialogs.c
-     * Function ChooseColor now has the ability to retain custom
-       colors between calls. These custom colors can be set and
-       read using an array as the third parameter.
+  * core\source\c_dialogs.c
+    * Function ChooseColor now has the ability to retain custom
+      colors between calls. These custom colors can be set and
+      read using an array as the third parameter.
 
 2020-05-14 20:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_image.c
-     ! Parameter validation at function _OOHG_SIZEOFHBITMAP.
+  * core\source\c_image.c
+    ! Parameter validation at function _OOHG_SIZEOFHBITMAP.
 
 2020-05-14 20:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_controlmisc.prg
-     + Function _OOHG_ControlObjects() that returns a clone of
-       OOHG's _OOHG_aControlObjects array.
+  * core\source\h_controlmisc.prg
+    + Function _OOHG_ControlObjects() that returns a clone of
+      OOHG's _OOHG_aControlObjects array.
 
 2020-05-14 20:15 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_hmg_compat.ch
-     + Translate for IsThemed() function.
+  * core\include\i_hmg_compat.ch
+    + Translate for IsThemed() function.
 
 2020-05-14 20:14 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_hb_compat.ch
-     + Translate for IsExe64() function.
+  * core\include\i_hb_compat.ch
+    + Translate for IsExe64() function.
 
 2020-05-14 20:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_pseudofunc.ch
-     * Use new defines in OOHGVersion() pseudofunction.
+  * core\include\i_pseudofunc.ch
+    * Use new defines in OOHGVersion() pseudofunction.
 
 2020-05-14 20:09 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_window.ch
-     + Support for Cargo and Cursor properties to semioop syntax.
+  * core\include\i_window.ch
+    + Support for Cargo and Cursor properties to semioop syntax.
 
 2020-05-14 20:06 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.ch
-   * core\include\oohg.h
-     + #include "oohgversion.h"
+  * core\include\oohg.ch
+  * core\include\oohg.h
+    + #include "oohgversion.h"
 
 2020-05-14 19:59 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
    + core\include\oohgversion.h
      ; Defines related to the library's version information.
 
 2020-05-14 19:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-   * core\include\i_browse.ch
-   * core\include\i_grid.ch
-   * core\include\i_xbrowse.ch
-   * core\source\h_browse.prg
-   * core\source\h_xbrowse.prg
-   * core\source\h_grid.prg
-     + Clause HEADERCOLORS.
-       Accepts an array of colors or an array of codeblocks or a
-       single codeblock that return colors (codeblocks receive the
-       column number as a parameter when evaluated).
+  * core\include\i_altsyntax.ch
+  * core\include\i_browse.ch
+  * core\include\i_grid.ch
+  * core\include\i_xbrowse.ch
+  * core\source\h_browse.prg
+  * core\source\h_xbrowse.prg
+  * core\source\h_grid.prg
+    + Clause HEADERCOLORS.
+      Accepts an array of colors or an array of codeblocks or a
+      single codeblock that return colors (codeblocks receive the
+      column number as a parameter when evaluated).
 
 2020-05-13 22:49 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_controlmisc.prg
-     ! Checkbox never looses focus after checking it.
+  * core\source\h_controlmisc.prg
+    ! Checkbox never looses focus after checking it.
 
 2020-05-04 20:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_controlmisc.prg
-     ! THIS doesn't point to the correct object when VALID
-       codeblock is executed.
+  * core\source\h_controlmisc.prg
+    ! THIS doesn't point to the correct object when VALID
+      codeblock is executed.
 
 2020-05-02 21:31 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-     + IMAGEALIGN clause for BUTTON control.
+  * core\include\i_altsyntax.ch
+    + IMAGEALIGN clause for BUTTON control.
 
 2020-04-19 16:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_combobox.ch
-     + Command SET COMBOINDEXISVALUEARRAY ON|OFF.
-     + Command SET COMBOINDEXISVALUEDBF ON|OFF.
-       ; Like COMBOINDEXISVALUE but specific.
-   * core\include\i_var.ch
-   * core\source\h_application.prg
-     - Global var _OOHG_ComboIndexIsValue.
-     + Global vars _OOHG_ComboIndexIsValueArray.
-       ; Defaults to .F.
-     + Global var _OOHG_ComboIndexIsValueDbf.
-       ; Defaults to .F.
-   * core\source\h_combo.prg
-     * DATA lUseIndexVal now defaults to NIL.
-     * DATA lUseIndexVal is set according to the data source.
+  * core\include\i_combobox.ch
+    + Command SET COMBOINDEXISVALUEARRAY ON|OFF.
+    + Command SET COMBOINDEXISVALUEDBF ON|OFF.
+    ; Like COMBOINDEXISVALUE but specific.
+  * core\include\i_var.ch
+  * core\source\h_application.prg
+    - Global var _OOHG_ComboIndexIsValue.
+    + Global vars _OOHG_ComboIndexIsValueArray.
+    ; Defaults to .F.
+    + Global var _OOHG_ComboIndexIsValueDbf.
+    ; Defaults to .F.
+  * core\source\h_combo.prg
+    * DATA lUseIndexVal now defaults to NIL.
+    * DATA lUseIndexVal is set according to the data source.
    ; This changes add the ability to change globaly only the combo's
      based on DBFs or only the ones based on arrays.
 
 2020-04-18 21:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_application.prg
-     ! RTE at method Value of class TCombo caused by wrong item
-       number assigned to define NDX_OOHG_COMBOINDEXISVALUE.
+  * core\source\h_application.prg
+    ! RTE at method Value of class TCombo caused by wrong item
+      number assigned to define NDX_OOHG_COMBOINDEXISVALUE.
 
 2020-04-18 20:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-   * core\include\i_combobox.ch
-     + Clause AUTOSIZE.
-     + Clauses INDEXISVALUE and SOURCEISVALUE.
-       ; INDEXISVALUE forces the use of sequential indexes as values.
-       ; SOURCEISVALUE forces the use of VALUESOURCE values.
-       ; See samples\combobox.
-     + Command SET COMBOINDEXISVALUE ON|OFF.
-       ; ON means that new combos without one of the previous clauses
-         will behave as if they have INDEXISVALUE clause.
-       ; OFF means that new combos without one of the previous clauses
-         will behave as if they have SOURCEISVALUE clause.
-       ; OFF is the default value.
-   * core\include\i_var.ch
-   * core\source\h_application.prg
-     + Global var _OOHG_ComboIndexIsValue.
-       ; Defaults to .F.
-   * core\source\h_combo.prg
-     + Data lUseIndexVal.
-     + New parameters to method Define.
-     * Do not force initialization of class datas lDelayLoad,
-       lIncremental and lRefresh.
-     + Support for autosize on method Define.
-     * Method Value:
-       ! Was ignoring empty values thus preventing the removal
-         of the current selection.
-       + Support for clauses INDEXISVALUE and SOURCEISVALUE.
-     * Method Autosize:
-       ! Was not setting the correct width.
-     * Methods Events, ItemValue, ItemBySource:
-       + Support for clauses INDEXISVALUE and SOURCEISVALUE.
+  * core\include\i_altsyntax.ch
+  * core\include\i_combobox.ch
+    + Clause AUTOSIZE.
+    + Clauses INDEXISVALUE and SOURCEISVALUE.
+      INDEXISVALUE forces the use of sequential indexes as values.
+      SOURCEISVALUE forces the use of VALUESOURCE values.
+      See samples\combobox.
+    + Command SET COMBOINDEXISVALUE ON|OFF.
+      ON means that new combos without one of the previous clauses
+      will behave as if they have INDEXISVALUE clause.
+      OFF means that new combos without one of the previous clauses
+      will behave as if they have SOURCEISVALUE clause.
+      OFF is the default value.
+  * core\include\i_var.ch
+  * core\source\h_application.prg
+    + Global var _OOHG_ComboIndexIsValue.
+      Defaults to .F.
+  * core\source\h_combo.prg
+    + Data lUseIndexVal.
+    + New parameters to method Define.
+    * Do not force initialization of class datas lDelayLoad,
+      lIncremental and lRefresh.
+    + Support for autosize on method Define.
+    * Method Value:
+      ! Was ignoring empty values thus preventing the removal
+        of the current selection.
+    + Support for clauses INDEXISVALUE and SOURCEISVALUE.
+    * Method Autosize:
+      ! Was not setting the correct width.
+    * Methods Events, ItemValue, ItemBySource:
+      + Support for clauses INDEXISVALUE and SOURCEISVALUE.
 
 2020-04-13 21:35 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\resources\oohg.rc
-     + New HBPRINTER messages.
+  * core\resources\oohg.rc
+    + New HBPRINTER messages.
 
-   * core\include\hbprinter_dyns.hbx
-     * Updated.
+  * core\include\hbprinter_dyns.hbx
+    * Updated.
 
-   * core\include\bostaurus.ch
-   * core\include\i_graph.ch
-     ! Compiler error when winprint.ch and bostaurus.ch are
-       included at the same time.
+  * core\include\bostaurus.ch
+  * core\include\i_graph.ch
+    ! Compiler error when winprint.ch and bostaurus.ch are
+      included at the same time.
 
-   * core\include\winprint.ch
-     + Command MOVE TO.
-     + Constant GDI_ERROR.
-     + Defines for handling colors when oohg.ch is not included.
-     ! "_OOHG_ActiveFrame undefined" error when oohg.ch is not included.
+  * core\include\winprint.ch
+    + Command MOVE TO.
+    + Constant GDI_ERROR.
+    + Defines for handling colors when oohg.ch is not included.
+    ! "_OOHG_ActiveFrame undefined" error when oohg.ch is not included.
 
-   * core\source\winprint.prg
+  * core\source\winprint.prg
 
-     ; At PRG level:
-     * Some comments, cosmetic changes, minor optimizations and defines
-       to improve source readability.
-     + DATA lReturnRGB INIT .T.
-       ; This forces method DxColors and pseudofunction HBPRNCOLOR to
-         return a COLORREF instead of an ARGB color.
-         INCOMPATIBLE.
-       ; Set this data to .F. to restore the previous behaviour.
-         In this case use ( aRGB_color % 0xFF000000 ) to set the color.
-     * Methods SetDevMode, SetUserMode, DrawText, Say, DefineImageList,
-       DrawImageList, Rectangle, FrameRect, RoundRect, FillRect, TextOut,
-       InvertRect, Ellipse, Arc, ArcTo, Chord, Pie, Polygon, PolyBezier,
-       PolyBezierTo, Line, LineTo, GetTextExtend, GetTextExtend_MM,
-       SetViewPortOrg, GetViewPortOrg, SetTextCharExtra, GetTextCharExtra,
-       GetTextAlign, SetTextAlign, Picture and Bitmap:
-       *  Now set ::Error aka HBPRNERROR.
-     + Method GetFontNames:
-       * Returns an array of font names.
-     + Method UnConvert to translate a position given in points to
-       its equivalent in ::Units.
-     * Method SetDevMode:
-       * No longer modifies ::hDCRef.
-     * Method SetUserMode:
-       * No longer modifies ::hDCRef.
-       ! RTE caused by a missing parameter in a function call.
-     * Method StartDoc: function RR_CreateFile replaced by RR_CreatEMFile.
-     * Method TextOut:
-       ! Amount of space the system should add to the break characters.
-     * Method Say:
-       ! Amount of space the system should add to the break characters.
-     + Method MoveTo to set the current drawing position of the page.
-       Use it to set the starting point for method PolyBezierTo.
-     * Method DxColors:
-       * Changed previous behaviour: by default now returns a COLORREF
-         instead of an ARGB color. To revert to previous behaviour set
-         ::lReturnRGB to .F.
-         INCOMPATIBLE.
-     * Method InitMessages:
-       + "Report is empty!" and "OK" messages.
-       + Support for loading new messages from oohg.rc
-     * Method PrevThumb:
-       ! Avoid double painting.
-       * Use image controls objects instead of win functions.
-       * Function RR_PlayFThumb replaced by RR_PlayThumb.
-       ! Size of thumbnails.
-     * Method PrevShow:
-       * Functions RR_PreviewPlay and RR_PreviewFPlay replaced
-         by RR_PlayPreview.
-       * Use the image control object instead of win functions.
-       - Unneeded call to function RR_ScrollWindow.
-       ! Size of preview page.
-     * Method PrevPrint:
-       * Function RR_PlayFEnhMetaFile replaced by RR_PlayEnhMetaFile.
-     * Method Preview:
-       ! RTE when the report has no pages.
-       ! Avoid double painting.
-       ! RTE when a non valid page number is entered in the combobox.
-       ! Missing caption on page preview form.
-       ! Size of thumbnails.
-       ! No thumbnails are shown when ::InMemory is .T.
-     * Method PrintOption:
-       + NOSYSMENU SIZE 9 styles to options form.
+    At PRG level:
+    * Some comments, cosmetic changes, minor optimizations and defines
+      to improve source readability.
+    + DATA lReturnRGB INIT .T.
+      This forces method DxColors and pseudofunction HBPRNCOLOR to
+      return a COLORREF instead of an ARGB color.
+      INCOMPATIBLE.
+      Set this data to .F. to restore the previous behaviour.
+      In this case use ( aRGB_color % 0xFF000000 ) to set the color.
+    * Methods SetDevMode, SetUserMode, DrawText, Say, DefineImageList,
+      DrawImageList, Rectangle, FrameRect, RoundRect, FillRect, TextOut,
+      InvertRect, Ellipse, Arc, ArcTo, Chord, Pie, Polygon, PolyBezier,
+      PolyBezierTo, Line, LineTo, GetTextExtend, GetTextExtend_MM,
+      SetViewPortOrg, GetViewPortOrg, SetTextCharExtra, GetTextCharExtra,
+      GetTextAlign, SetTextAlign, Picture and Bitmap: now they set
+      ::Error aka HBPRNERROR.
+    + Method GetFontNames:
+      * Returns an array of font names.
+    + Method UnConvert to translate a position given in points to
+      its equivalent in ::Units.
+    * Method SetDevMode:
+      * No longer modifies ::hDCRef.
+    * Method SetUserMode:
+      * No longer modifies ::hDCRef.
+      ! RTE caused by a missing parameter in a function call.
+    * Method StartDoc:
+      * Function RR_CreateFile replaced by RR_CreatEMFile.
+    * Method TextOut:
+      ! Amount of space the system should add to the break characters.
+    * Method Say:
+      ! Amount of space the system should add to the break characters.
+    + Method MoveTo to set the current drawing position of the page.
+      Use it to set the starting point for method PolyBezierTo.
+    * Method DxColors:
+      * Changed previous behaviour: by default now returns a COLORREF
+        instead of an ARGB color. To revert to previous behaviour set
+        ::lReturnRGB to .F.
+        INCOMPATIBLE.
+    * Method InitMessages:
+      + "Report is empty!" and "OK" messages.
+      + Support for loading new messages from oohg.rc
+    * Method PrevThumb:
+      ! Avoid double painting.
+      * Use image controls objects instead of win functions.
+      * Function RR_PlayFThumb replaced by RR_PlayThumb.
+      ! Size of thumbnails.
+    * Method PrevShow:
+      * Functions RR_PreviewPlay and RR_PreviewFPlay replaced
+        by RR_PlayPreview.
+      * Use the image control object instead of win functions.
+      - Unneeded call to function RR_ScrollWindow.
+      ! Size of preview page.
+    * Method PrevPrint:
+      * Function RR_PlayFEnhMetaFile replaced by RR_PlayEnhMetaFile.
+    * Method Preview:
+      ! RTE when the report has no pages.
+      ! Avoid double painting.
+      ! RTE when a non valid page number is entered in the combobox.
+      ! Missing caption on page preview form.
+      ! Size of thumbnails.
+      ! No thumbnails are shown when ::InMemory is .T.
+    * Method PrintOption:
+      + NOSYSMENU SIZE 9 styles to options form.
 
-     ; At C level:
-     - Unneeded header.
-     * Order of included headers.
-     + Some defines to improve source readability.
-     * Some changes for 64 bits support.
-     * Functions RR_TEXTOUT, RR_DRAWTEXT, RR_RECTANGLE, RR_SETVIEWPORTORG,
-       RR_GETVIEWPORTORG, RR_DRAWPICTURE, RR_DRAWIMAGELIST, RR_POLYGON,
-       RR_POLYBEZIER, RR_POLYBEZIERTO, RR_GETTEXTEXTEND, RR_INVERTRECT,
-       RR_GETTEXTEXTEND_MM, RR_ROUNDRECT, RR_ELLIPSE, RR_CHORD, RR_ARCTO,
-       RR_ARC, RR_PIE, RR_FILLRECT, RR_FRAMERECT, RR_LINE, RR_LINETO
-       and RR_DRAWBITMAP now return 1 on error or 0 on success.
-     * Added one item to devcaps array in order to use the same
-       indexes used at PRG level.
-     - Members preview and hbmp from structure HBPRINTERDATA.
-     + Function EnumFontsCallBack.
-     + Function RR_GETFONTNAMES.
-     * Function RR_PRINTDIALOG:
-       * Initial page interval set to 1-65535.
-       + Min page set to 1 and max page set 65535.
-       + Initial number of copies is set to 1.
-       + Check for a NULL HDC.
-       + Check to correctly set the number of copies in old Windows.
-     * Function RR_RESETPRINTER:
-       ! Memory leak.
-     * Function RR_DELETEDC:
-       ! Memory and resource leaks.
-       * Use C pointer instead PRG pointer to release the DC.
-     * Function RR_SETDEVMODE:
-       * Now returns NIL when change fails.
-     * Function RR_SETUSERMODE:
-       * Now it only processes DMPAPER_USER property.
-       * Now returns NIL when change fails.
-     * Function RR_GETDEFAULTPRINTER:
-       ! Member PrinterDefault of structure HBPRINTERDATA wasn't updated
-         when no default printer was found.
-       ! Return value was wrong when no default printer wasn't found.
-     * Function RR_SETPOLYFILLMODE:
-       ! Wrong casting of mode parameter.
-     * Function RR_SETBKMODE:
-       * Now returns 0 when change fails.
-     * Function RR_SAVEMETAFILE:
-       * Now returns the handle to the new EMF.
-     * Function RR_CreatEMFile now handles in-memory and at-disk files.
-     - Function RR_CreateFile.
-     - Function RR_PICTURE superseded by RR_DRAWPICTURE.
-     + Function RR_DrawIPicture:
-       ; Draws an image on a DC from an IPicture object.
-       ; Derives form previous version of function RR_DRAWPICTURE but.
-         uses diferent default values for image dimensions.
-     * Function RR_DRAWPICTURE:
-       * Now uses function RR_DrawIPicture.
-     * Function RR_DRAWBITMAP:
-       * Now uses function RR_DrawIPicture.
-     * Function RR_CREATEIMAGELIST:
-       * Now returns NULL on fail.
-     * Function RR_DRAWIMAGELIST:
-       ! RTE caused by access to the wrong parameter.
-     + Function RR_MOVETO:
-       ; Sets the current drawing position inside the page.
-     - Function RR_ScrollWindow.
-     + Function RR_PLAYPREVIEW:
-       ; This new function plays the metafiles on a 24-bit bitmap.
-       ; It handles both in-memory and at-disk files.
-       ! Page preview shows wrong images when the pages are created
-         using commands INVERTRECT or DRAW IMAGELIST.
-     - Function RR_PREVIEWPLAY substituted by RR_PLAYPREVIEW.
-     - Function RR_PREVIEWFPLAY substituted by RR_PLAYPREVIEW.
-     * Function RR_PLAYTHUMB:
-       * Metafiles are played on a 24-bit bitmap.
-       * Both in-memory and at-disk metafiles are now supported.
-       ! Thumbnails show wrong images when the pages are createad
-         using commands INVERTRECT or DRAW IMAGELIST.
-     - Function RR_PLAYFTHUMB substituted by RR_PLAYTHUMB.
-     * Function RR_PLAYENHMETAFILE:
-       * Both in-memory and at-disk metafiles are now supported.
-       ! Some resource leaks.
-     - Function RR_PLAYFENHMETAFILE substituted by RR_PLAYENHMETAFILE.
+    At C level:
+    - Unneeded header.
+    * Order of included headers.
+    + Some defines to improve source readability.
+    * Some changes for 64 bits support.
+    * Functions RR_TEXTOUT, RR_DRAWTEXT, RR_RECTANGLE, RR_SETVIEWPORTORG,
+      RR_GETVIEWPORTORG, RR_DRAWPICTURE, RR_DRAWIMAGELIST, RR_POLYGON,
+      RR_POLYBEZIER, RR_POLYBEZIERTO, RR_GETTEXTEXTEND, RR_INVERTRECT,
+      RR_GETTEXTEXTEND_MM, RR_ROUNDRECT, RR_ELLIPSE, RR_CHORD, RR_ARCTO,
+      RR_ARC, RR_PIE, RR_FILLRECT, RR_FRAMERECT, RR_LINE, RR_LINETO
+      and RR_DRAWBITMAP now return 1 on error or 0 on success.
+    * Added one item to devcaps array in order to use the same
+      indexes used at PRG level.
+    - Members preview and hbmp from structure HBPRINTERDATA.
+    + Function EnumFontsCallBack.
+    + Function RR_GETFONTNAMES.
+    * Function RR_PRINTDIALOG:
+      * Initial page interval set to 1-65535.
+      + Min page set to 1 and max page set 65535.
+      + Initial number of copies is set to 1.
+      + Check for a NULL HDC.
+      + Check to correctly set the number of copies in old Windows.
+    * Function RR_RESETPRINTER:
+      ! Memory leak.
+    * Function RR_DELETEDC:
+      ! Memory and resource leaks.
+      * Use C pointer instead PRG pointer to release the DC.
+    * Function RR_SETDEVMODE:
+      * Now returns NIL when change fails.
+    * Function RR_SETUSERMODE:
+      * Now it only processes DMPAPER_USER property.
+      * Now returns NIL when change fails.
+    * Function RR_GETDEFAULTPRINTER:
+      ! Member PrinterDefault of structure HBPRINTERDATA wasn't updated
+        when no default printer was found.
+      ! Return value was wrong when no default printer wasn't found.
+    * Function RR_SETPOLYFILLMODE:
+      ! Wrong casting of mode parameter.
+    * Function RR_SETBKMODE:
+      * Now returns 0 when change fails.
+    * Function RR_SAVEMETAFILE:
+      * Now returns the handle to the new EMF.
+    * Function RR_CreatEMFile now handles in-memory and at-disk files.
+    - Function RR_CreateFile.
+    - Function RR_PICTURE superseded by RR_DRAWPICTURE.
+    + Function RR_DrawIPicture:
+      ; Draws an image on a DC from an IPicture object.
+      ; Derived form previous version of function RR_DRAWPICTURE but
+        uses diferent default values for image dimensions.
+    * Function RR_DRAWPICTURE:
+      * Now uses function RR_DrawIPicture.
+    * Function RR_DRAWBITMAP:
+      * Now uses function RR_DrawIPicture.
+    * Function RR_CREATEIMAGELIST:
+      * Now returns NULL on fail.
+    * Function RR_DRAWIMAGELIST:
+      ! RTE caused by access to the wrong parameter.
+    + Function RR_MOVETO:
+      ; Sets the current drawing position inside the page.
+    - Function RR_ScrollWindow.
+    + Function RR_PLAYPREVIEW:
+      ; This new function plays the metafiles on a 24-bit bitmap.
+      ; It handles both in-memory and at-disk files.
+      ! Page preview shows wrong images when the pages are created
+        using commands INVERTRECT or DRAW IMAGELIST.
+    - Function RR_PREVIEWPLAY substituted by RR_PLAYPREVIEW.
+    - Function RR_PREVIEWFPLAY substituted by RR_PLAYPREVIEW.
+    * Function RR_PLAYTHUMB:
+      * Metafiles are played on a 24-bit bitmap.
+      * Both in-memory and at-disk metafiles are now supported.
+      ! Thumbnails show wrong images when the pages are createad
+        using commands INVERTRECT or DRAW IMAGELIST.
+    - Function RR_PLAYFTHUMB substituted by RR_PLAYTHUMB.
+    * Function RR_PLAYENHMETAFILE:
+      * Both in-memory and at-disk metafiles are now supported.
+      ! Some resource leaks.
+    - Function RR_PLAYFENHMETAFILE substituted by RR_PLAYENHMETAFILE.
 
 2020-04-10 20:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     * Method PrintResource of TPrintBase:
-       + Check for empty resource name.
-     * Method PrintImage of TPrintBase:
-       + Check for empty file name.
-     * Methods PrintResource, PrintBitmap, PrintImage, PrintLine,
-       PrintRectangle, PrintRoundRectangle of TPrintBase:
-       - Default values for ommited parameters.
-       * Now return the return value of the subclass method.
-     * Method PrintBitmapX of TMiniPrint:
-       - Default values of printing coordinates.
-     * Methods PrintDataX, PrintBitmapX, PrintImageX, PrintLineX,
-       PrintRectangleX and PrintRoundRectangleX of THBPrinter:
-       * Now return HBPRNERROR.
-     * Methods PrintBarcodeX, PrintBitmapX and PrintImageX
-       of THBPrinter:
-       - Default values for ommited printing coordinates.
-     * Method PrintBitmapX and PrintImageX of THBPrinter:
-       ! Support for the extension rectangle.
+  * core\source\h_print.prg
+    * Method PrintResource of TPrintBase:
+      + Check for empty resource name.
+    * Method PrintImage of TPrintBase:
+      + Check for empty file name.
+    * Methods PrintResource, PrintBitmap, PrintImage, PrintLine,
+      PrintRectangle, PrintRoundRectangle of TPrintBase:
+      - Default values for ommited parameters.
+      * Now return the return value of the subclass method.
+    * Method PrintBitmapX of TMiniPrint:
+      - Default values of printing coordinates.
+    * Methods PrintDataX, PrintBitmapX, PrintImageX, PrintLineX,
+      PrintRectangleX and PrintRoundRectangleX of THBPrinter:
+      * Now return HBPRNERROR.
+    * Methods PrintBarcodeX, PrintBitmapX and PrintImageX
+      of THBPrinter:
+      - Default values for ommited printing coordinates.
+    * Method PrintBitmapX and PrintImageX of THBPrinter:
+      ! Support for the extension rectangle.
 
 2020-04-08 23:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     ! Resource leak.
+  * core\source\bostaurus.prg
+    ! Resource leak.
 
 2020-04-05 10:02 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     * Changed parameter testing order at method PrintBitmapX.
+  * core\source\h_print.prg
+    * Changed parameter testing order at method PrintBitmapX.
 
 2020-04-05 09:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\winprint.ch
-     * Resulting pattern of INIT PRINTSYS is now optional.
+  * core\include\winprint.ch
+    * Resulting pattern of INIT PRINTSYS is now optional.
 
 2020-04-05 09:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     + Support for releasing non-active forms.
+  * core\source\h_form.prg
+    + Support for releasing non-active forms.
 
 2020-04-05 09:49 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_hmg_compat.ch
-     + Translate for BUTTON's DEFAULT clause.
+  * core\include\i_hmg_compat.ch
+    + Translate for BUTTON's DEFAULT clause.
 
 2020-03-16 18:53 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-     ! The second time PrintBitmap is called for the same image
-       nothing is printed.
-     ! Resource leak.
+  * core\source\miniprint.prg
+    ! The second time PrintBitmap is called for the same image
+      nothing is printed.
+    ! Resource leak.
 
 2020-03-10 21:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_image.c
-   * core\source\h_button.prg
-     * Use HWNDret instead of HB_RETNL+(LONG_PTR) at
-       function _OOHG_COPYBITMAP.
+  * core\source\c_image.c
+  * core\source\h_button.prg
+    * Use HWNDret instead of HB_RETNL+(LONG_PTR) at
+      function _OOHG_COPYBITMAP.
 
 2020-03-10 21:04 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     * Avoid waiting on error at WAITRUN function.
+  * core\source\c_winapimisc.c
+    * Avoid waiting on error at WAITRUN function.
 
 2020-03-02 17:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_tree.prg
-     ! RTE "Message not found: TTREE:HWNDEDITCTRL" when pressing
-       ESC key on a tree control.
+  * core\source\h_tree.prg
+    ! RTE "Message not found: TTREE:HWNDEDITCTRL" when pressing
+      ESC key on a tree control.
 
 2020-02-25 21:12 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     ! After pressing ESC on a TGridControlComboBox's list
-       the app becomes unresponsive.
+  * core\source\h_form.prg
+    ! After pressing ESC on a TGridControlComboBox's list
+      the app becomes unresponsive.
 
 2020-02-13 20:24 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_button.prg
-     ! RTE "Message not found LNOLOADTRANSPARENT".
+  * core\source\h_button.prg
+    ! RTE "Message not found LNOLOADTRANSPARENT".
 
 2020-02-05 17:59 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_combo.prg
-     ! Some items are not shown when using a source with
-       an active order.
-     - Data nLastItem.
-     + Data nNextItem.
+  * core\source\h_combo.prg
+    ! Some items are not shown when using a source with
+      an active order.
+    - Data nLastItem.
+    + Data nNextItem.
 
 2019-12-30 18:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-12-30 18:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_combo.prg
-     ! Items are not shown if they're added at OnInitProcedure
-       using method AddItem.
-     + Data aValueSource.
-     + Data lUsesTComboArray.
-     + Method IsValTypeOK.
-     + Method ValueType.
-     * ITEMS clause will now default to an empty arrays when missing.
-     * Combo will use a TComboArray object if the WorkaArea parameter
-       is not a datasource (object or work area).
-     + Some validations to prevent adding items with wrong type values.
-       All items values must be of the same type (numeric or char).
-     % Methods ReadData, Value, ItemValue, ItemBySource.
-     ! Methods AddItem, InsertItem and DeleteItem for array based combos.
-     ! Casting at functions COMBOINSERTSTRING, COMBOSETCURSEL,
-       COMBOBOXDELETESTRING, COMBOGETSTRING and COMBOITEM.
-     * Removed length limit from function COMBOITEM.
-     * Function TCOMBO_INSERT_ITEM now returns item count.
-     + Data lBof of class TComboArray.
-     + Method Append to class TComboArray.
-     + Method Bof to class TComboArray.
-     + Method Delete to class TComboArray.
-     + Method GoBottom to class TComboArray.
-     + Method GoTop to class TComboArray.
-     + Method Insert to class TComboArray.
-     * Method New now positions the array to it's first item.
-     * Some vars were renamed to improve clarity.
+  * core\source\h_combo.prg
+    ! Items are not shown if they're added at OnInitProcedure
+      using method AddItem.
+    + Data aValueSource.
+    + Data lUsesTComboArray.
+    + Method IsValTypeOK.
+    + Method ValueType.
+    * ITEMS clause will now default to an empty arrays when missing.
+    * Combo will use a TComboArray object if the WorkaArea parameter
+      is not a datasource (object or work area).
+    + Some validations to prevent adding items with wrong type values.
+      ; All items values must be of the same type (numeric or char).
+    % Methods ReadData, Value, ItemValue, ItemBySource.
+    ! Methods AddItem, InsertItem and DeleteItem for array based combos.
+    ! Casting at functions COMBOINSERTSTRING, COMBOSETCURSEL,
+      COMBOBOXDELETESTRING, COMBOGETSTRING and COMBOITEM.
+    * Removed length limit from function COMBOITEM.
+    * Function TCOMBO_INSERT_ITEM now returns item count.
+    + Data lBof of class TComboArray.
+    + Method Append to class TComboArray.
+    + Method Bof to class TComboArray.
+    + Method Delete to class TComboArray.
+    + Method GoBottom to class TComboArray.
+    + Method GoTop to class TComboArray.
+    + Method Insert to class TComboArray.
+    * Method New now positions the array to it's first item.
+    * Some vars were renamed to improve clarity.
 
 2019-12-30 18:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     * Added third parameter lShrink to function _OOHG_DeleteArrayItem.
-     * Now uses Harbour's function hb_ADel.
-     + Function _OOHG_InsertArrayItem( aArray, nItem, uValue, lGrow ).
+  * core\source\h_windows.prg
+    * Added third parameter lShrink to function _OOHG_DeleteArrayItem.
+    * Now uses Harbour's function hb_ADel.
+    + Function _OOHG_InsertArrayItem( aArray, nItem, uValue, lGrow ).
 
 2019-12-24 19:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! Error 9023 at LISTVIEW_GETCOLUMNORDER when
-       deleting a column and the grid has no columns.
+  * core\source\h_grid.prg
+    ! Error 9023 at LISTVIEW_GETCOLUMNORDER when
+      deleting a column and the grid has no columns.
 
 2019-12-17 21:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
-   * core\include\oohg.h
-     + Declarations of functions ProcGetThemeMargins and _OOHG_CopyBitmap.
-   * core\source\c_winapimisc.c
-     + ProcGetThemeMargins initialization at function _UxTheme_Init.
-   * core\source\c_image.c
-     * Some parameters renamed and other minor changes in functions
-       _OOHG_ScaleImage, _OOHG_SETBITMAP, _OOHG_SCALEIMAGE.
-     + C function _OOHG_CopyBitmap to copy all or part of a bitmap
-       into a new bitmap.
-     * Function _OOHG_COPYBITMAP now calls _OOHG_CopyBitmap.
-   * core\source\c_windows.c
-     + C functions CenterIntoDesktop and CenterIntoScreen.
-     + Second parameter to function C_Center:
-       0 means center the window on the screen and
-       1 means center the window on the desktop workarea.
-     * Function C_Center now returns 0, 1 or -1 (nothing done).
-   * core\source\h_button.prg
-     * Some comments.
-     * Image alignment now defaults to LEFT is button has caption
-       or to CENTER if not.
-     * Margins default to theme's margins if themes are enabled.
-     * Image are always loaded at full size.
-     * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
-     % Method RePaint.
-     % Function SETIMAGEXP.
-     * Button's imagelist if no longer accesible via ::ImageList
-       or any other method or function.
-     + Function THEMEMARGINS.
-     ! Painting always defaults to OOHGDRAW.
-     ! Button shows wrong image alignment.
-     ! Image disappears when button is repainted.
-     ! Image placement on customdraw buttons.
-   * core\source\h_form.prg
-     * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
-     * Method Center to TFormInternal class.
-   * core\source\h_image.prg
-     * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
-   * core\source\h_picture.prg
-     * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
+  * core\include\oohg_dyns.hbx
+    * Updated.
+  * core\include\oohg.h
+    + Declarations of functions ProcGetThemeMargins and _OOHG_CopyBitmap.
+  * core\source\c_winapimisc.c
+    + ProcGetThemeMargins initialization at function _UxTheme_Init.
+  * core\source\c_image.c
+    * Some parameters renamed and other minor changes in functions
+      _OOHG_ScaleImage, _OOHG_SETBITMAP, _OOHG_SCALEIMAGE.
+    + C function _OOHG_CopyBitmap to copy all or part of a bitmap
+      into a new bitmap.
+    * Function _OOHG_COPYBITMAP now calls _OOHG_CopyBitmap.
+  * core\source\c_windows.c
+    + C functions CenterIntoDesktop and CenterIntoScreen.
+    + Second parameter to function C_Center:
+      0 means center the window on the screen and
+      1 means center the window on the desktop workarea.
+    * Function C_Center now returns 0, 1 or -1 (nothing done).
+  * core\source\h_button.prg
+    * Some comments.
+    * Image alignment now defaults to LEFT is button has caption
+      or to CENTER if not.
+    * Margins default to theme's margins if themes are enabled.
+    * Image are always loaded at full size.
+    * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
+    % Method RePaint.
+    % Function SETIMAGEXP.
+    * Button's imagelist if no longer accesible via ::ImageList
+      or any other method or function.
+    + Function THEMEMARGINS.
+    ! Painting always defaults to OOHGDRAW.
+    ! Button shows wrong image alignment.
+    ! Image disappears when button is repainted.
+    ! Image placement on customdraw buttons.
+  * core\source\h_form.prg
+    * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
+    * Method Center to TFormInternal class.
+  * core\source\h_image.prg
+    * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
+  * core\source\h_picture.prg
+    * Function _OOHG_CopyBitmap was replaced by _OOHG_CopyImage.
 
 2019-12-17 20:43 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     ! Resource leak.
+  * core\source\bostaurus.prg
+    ! Resource leak.
 
 2019-12-17 20:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\ChangeLog_004.txt
-     ! Typos.
+  * core\ChangeLog_004.txt
+    ! Typos.
 
 2019-12-17 20:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! GridByCell allows edition of a readonly column.
+  * core\source\h_grid.prg
+    ! GridByCell allows edition of a readonly column.
 
 2019-12-09 19:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_color.ch
-     * CYAN color was renamed to LCYAN (light cyan).
-     + True CYAN color.
-     + Metro UI colors.
+  * core\include\i_color.ch
+    * CYAN color was renamed to LCYAN (light cyan).
+    + True CYAN color.
+    + Metro UI colors.
 
 2019-12-09 19:36 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_label.ch
-     - Unneeded brackets.
+  * core\include\i_label.ch
+    - Unneeded brackets.
 
 2019-12-06 21:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-12-06 21:20 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_var.ch
-     + Translate for _OOHG_ActiveTree var.
-   * core\source\h_application.prg
-     + Support for _OOHG_ActiveTree var.
-   * core\source\h_tree.prg
-     - Static PRG var _OOHG_ActiveTree.
-     - DATA hWndEditCtrl from TTree class.
-     + DATA oEditCtrl to TTree class.
-     + DATA PreviousItem to TTree class.
-     * Function TTree_OnMouseDrag now updates data PreviousItem
-       of the target tree control.
-     ! Return value of function TREEVIEW_GETSELECTION.
-     ! Return value of function TREEVIEW_GETSELECTIONID.
-     - Static C var lpfnOldWndProcEditCtrl.
-     - Static C var hwndTreeView.
-     - Static C function SubClassFuncEditCtrl.
-     - Function SUBCLASSEDITCTRL.
-     ! Return value of function TREEVIEW_BEGINDRAG.
-     - Static C var htiPrevious.
-     * Added 4th parameter and return value to function
-       TREEVIEW_AUTOEXPAND to make it thread safe.
-     + Class TTreeEdit to handle the edit control that is used
-       to edit the item's label.
-     + Functions INITEDITTREE and TREEVIEW_PROCESSEDITMSG.
-     * Some format.
-     ; Module is now thread safe.
+  * core\include\i_var.ch
+    + Translate for _OOHG_ActiveTree var.
+  * core\source\h_application.prg
+    + Support for _OOHG_ActiveTree var.
+  * core\source\h_tree.prg
+    - Static PRG var _OOHG_ActiveTree.
+    - DATA hWndEditCtrl from TTree class.
+    + DATA oEditCtrl to TTree class.
+    + DATA PreviousItem to TTree class.
+    * Function TTree_OnMouseDrag now updates data PreviousItem
+      of the target tree control.
+    ! Return value of function TREEVIEW_GETSELECTION.
+    ! Return value of function TREEVIEW_GETSELECTIONID.
+    - Static C var lpfnOldWndProcEditCtrl.
+    - Static C var hwndTreeView.
+    - Static C function SubClassFuncEditCtrl.
+    - Function SUBCLASSEDITCTRL.
+    ! Return value of function TREEVIEW_BEGINDRAG.
+    - Static C var htiPrevious.
+    * Added 4th parameter and return value to function
+      TREEVIEW_AUTOEXPAND to make it thread safe.
+    + Class TTreeEdit to handle the edit control that is used
+      to edit the item's label.
+    + Functions INITEDITTREE and TREEVIEW_PROCESSEDITMSG.
+    * Some format.
+    ; Module is now thread safe.
 
 2019-12-05 22:37 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     + Support for clause AUTOSKIP to classes TGridControlTextBox
-       and TGridControlTextBoxAction.
+  * core\source\h_grid.prg
+    + Support for clause AUTOSKIP to classes TGridControlTextBox
+      and TGridControlTextBoxAction.
 
 2019-12-05 21:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     ! Main is obscured by a non-app window after releasing
-       a TGridControl created by a grid defined at a form
-       that is not a child of Main. The same problem happens
-       after releasing a modal dialog created by a form that
-       is not a child of Main.
-       See https://github.com/oohg/core/issues/183
+  * core\source\h_form.prg
+    ! Main is obscured by a non-app window after releasing
+      a TGridControl created by a grid defined at a form
+      that is not a child of Main. The same problem happens
+      after releasing a modal dialog created by a form that
+      is not a child of Main.
+      See https://github.com/oohg/core/issues/183
 
 2019-11-24 21:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     ! Previous form is not focused after releasing a modal
-       form.
+  * core\source\h_form.prg
+    ! Previous form is not focused after releasing a modal
+      form.
 
 2019-11-22 21:23 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\BuildApp_hbmk2.bat
-     ! .exe erasing when an extension is specified.
+  * core\BuildApp_hbmk2.bat
+    ! .exe erasing when an extension is specified.
 
 2019-11-22 18:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_font.c
-     * Comment.
+  * core\source\c_font.c
+    * Comment.
 
 2019-11-21 19:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-     ! Codeblock is not evaluated because of bad result marker.
+  * core\include\i_altsyntax.ch
+    ! Codeblock is not evaluated because of bad result marker.
 
 2019-11-21 18:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-   * core\include\i_combobox.ch
-     + Clause NOLOADTRANSPARENT.
-       When present the images are loaded to the imagelist
-       using CLR_NONE instead of CLR_DEFAULT.
-     + Clause ONCANCEL.
-   * core\include\i_windefs.ch
-     + Define for CBN_SELENDCANCEL.
-   * core\source\h_combobox.prg
-     + DATA OnCancel.
-       This block is executed when the user selects an item
-       but then selects another control or closes the form.
-     + Parameters lNoTrans and bOnCancel to method Define
-       of class TCombo.
-     + Handler for CBN_SELENDCANCEL at method Events_Command
-       of class TCombo.
+  * core\include\i_altsyntax.ch
+  * core\include\i_combobox.ch
+    + Clause NOLOADTRANSPARENT.
+      When present the images are loaded to the imagelist
+      using CLR_NONE instead of CLR_DEFAULT.
+    + Clause ONCANCEL.
+  * core\include\i_windefs.ch
+    + Define for CBN_SELENDCANCEL.
+  * core\source\h_combobox.prg
+    + DATA OnCancel.
+      This block is executed when the user selects an item
+      but then selects another control or closes the form.
+    + Parameters lNoTrans and bOnCancel to method Define
+      of class TCombo.
+    + Handler for CBN_SELENDCANCEL at method Events_Command
+      of class TCombo.
 
 2019-11-20 21:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_graph.ch
-     + Clause TRANSPARENT to DRAW RECTANGLE, DRAW ROUNDRECTANGLE,
-       DRAW ELLIPSE, DRAW PIE and DRAW POLYGON commands.
-     ; To draw using a null brush ommit FILLCOLOR and add TRANSPARENT.
-   * core\source\c_graph.c
-     + Member BOOL usenull to structure _OOHG_GraphData.
-     * _OOHG_GraphCommand will use a null brush to paint when
-       usenull member is TRUE.
-     + Parameter usenull to function _OOHG_NEWGRAPHCOMMAND.
-   * core\source\h_graph.prg
-     + Parameter transparent to functions DrawLine, DrawRect,
-       DrawRoundRect, DrawEllipse, DrawPie and DrawwPolygon.
+  * core\include\i_graph.ch
+    + Clause TRANSPARENT to DRAW RECTANGLE, DRAW ROUNDRECTANGLE,
+      DRAW ELLIPSE, DRAW PIE and DRAW POLYGON commands.
+    ; To draw using a null brush ommit FILLCOLOR and add TRANSPARENT.
+  * core\source\c_graph.c
+    + Member BOOL usenull to structure _OOHG_GraphData.
+    * _OOHG_GraphCommand will use a null brush to paint when
+      usenull member is TRUE.
+    + Parameter usenull to function _OOHG_NEWGRAPHCOMMAND.
+  * core\source\h_graph.prg
+    + Parameter transparent to functions DrawLine, DrawRect,
+      DrawRoundRect, DrawEllipse, DrawPie and DrawwPolygon.
 
 2019-11-20 18:43 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_label.prg
-     % Small simplification.
-   * core\source\h_combobox.prg
-     ! DisplayValue is cleared at form's activation.
+  * core\source\h_label.prg
+    % Small simplification.
+  * core\source\h_combobox.prg
+    ! DisplayValue is cleared at form's activation.
 
 2019-11-20 18:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-11-20 18:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.ch
-     - Unneeded REQUEST.
-     * HB_GT_GUI_DEFAULT is requested only if _OOHG_CONSOLEMODE_
-       constant is not defined at runtime. This constant must be
-       defined when OOHG libraries are build to avoid forcing
-       GTGUI as default GT for every app.
-     ! Console mode compilation using HBMK2. The resulting exe
-       does nothing but stay in memory.
+  * core\include\oohg.ch
+    - Unneeded REQUEST.
+    * HB_GT_GUI_DEFAULT is requested only if _OOHG_CONSOLEMODE_
+      constant is not defined at runtime. This constant must be
+      defined when OOHG libraries are build to avoid forcing
+      GTGUI as default GT for every app.
+    ! Console mode compilation using HBMK2. The resulting exe
+      does nothing but stay in memory.
 
 2019-11-20 18:05 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     - Unneeded ANNOUNCE.
+  * core\source\h_init.prg
+    - Unneeded ANNOUNCE.
 
 2019-11-20 18:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\BuildApp_hbmk2.bat
-     ! Support for console mode.
+  * core\BuildApp_hbmk2.bat
+    ! Support for console mode.
 
 2019-11-20 18:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\buildapp.bat
-   * core\oohg.hbc
-     * Vars HG_HB* renamed as HG_HM*
+  * core\buildapp.bat
+  * core\oohg.hbc
+    * Vars HG_HB* renamed as HG_HM*
 
 2019-11-20 18:02 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\ChangeLog_005.txt
-   * core\compile.bat
-   * core\resources\CompileRes_mingw.bat
-     * References to files oohg_hb* changed to oohg_hm*
+  * core\ChangeLog_005.txt
+  * core\compile.bat
+  * core\resources\CompileRes_mingw.bat
+    * References to files oohg_hb* changed to oohg_hm*
 
 2019-11-20 18:01 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_bcc.bat
-     + Switch /V.
-     ! Define for console mode.
-     * Define for console mode is set for Harbour compiler only.
-     ! Libraries order.
-     ! Optional libraries.
+  * core\compile_bcc.bat
+    + Switch /V.
+    ! Define for console mode.
+    * Define for console mode is set for Harbour compiler only.
+    ! Libraries order.
+    ! Optional libraries.
 
 2019-11-20 18:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_MINGW.BAT
-     * Comment.
-     * Define for console mode is set for Harbour compiler only.
-     ! Libraries order.
-     ! Optional libraries.
-     * Use LIB_GUI instead of hardwired path.
+  * core\compile_MINGW.BAT
+    * Comment.
+    * Define for console mode is set for Harbour compiler only.
+    ! Libraries order.
+    ! Optional libraries.
+    * Use LIB_GUI instead of hardwired path.
 
 2019-11-20 18:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_misc.ch
-     + SET MIXEDMODE command.
-       It equals REQUEST HB_GET_WIN_DEFAULT.
+  * core\include\i_misc.ch
+    + SET MIXEDMODE command.
+      It equals REQUEST HB_GET_WIN_DEFAULT.
 
 2019-11-20 17:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.hbp
-   * core\source\hbprinter.hbp
-   * core\source\miniprint.hbp
-   * core\source\oohg.hbp
-   * core\source\common_make.bat
-     + _OOHG_CONSOLEMODE_ define.
-       This constant must be defined when building libraries
-       that include oohg.ch to avoid forcing the request of
-       HB_GET_GUI_DEFAULT on every app.
+  * core\source\bostaurus.hbp
+  * core\source\hbprinter.hbp
+  * core\source\miniprint.hbp
+  * core\source\oohg.hbp
+  * core\source\common_make.bat
+    + _OOHG_CONSOLEMODE_ define.
+      This constant must be defined when building libraries
+      that include oohg.ch to avoid forcing the request of
+      HB_GET_GUI_DEFAULT on every app.
 
 2019-11-20 17:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimsc.c
-     ! Return value of function WAITRUN.
-     ! Casting.
-     ! Handle leaks.
-     + Functions WaitRunTerm and IsExeRunning.
+  * core\source\c_winapimsc.c
+    ! Return value of function WAITRUN.
+    ! Casting.
+    ! Handle leaks.
+    + Functions WaitRunTerm and IsExeRunning.
 
 2019-11-20 17:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_combobox.ch
-     - Clause HSCROLL.
-     + Clause NOHSCROLL.
-     + Clause NOCLONE.
-       Set to .T. to allow the control to use the ITEMS array
-       without cloning it. Beware that the app may crash if
-       you mishandle the original array. Defaults to .F.
-   * core\include\i_altsyntax.ch
-     + Support for combobox clauses NOHSCROLL and NOCLONE.
-   * core\source\h_combobox.prg
-     * Parameter lHScroll of method Define replace by lNoHScroll.
-       Combo's horizontal text scrolling is now the default
-       behaviour. Add NOHSCROLL clause to get old behaviour.
-       INCOMPATIBLE.
-     - Data aRows from class TCombo.
-     + Data lNoClone to class TCombo.
-       Defaulfs to .F.
-     + Parameter lNoClose to method Define.
-     + Method GetItems to class TCombo.
-       Returns an array with all the items that are loaded in the
-       combobox. The array is build from the Windows' control.
-     + Method SelectString to class TCombo.
-       Searches the list for an item that begins with specified
-       string. If found, it's selected and copied to the display.
-     + Class TComboArray to handle ITEMS array as a database.
-     * Method ValueSource will now only return codeblocks.
-     * Methods Rows, Refresh, ReadData and DeleteAllItems were
-       adapted to work with class TComboArray.
-     * Removed length limit from function COMBOGETSTRING.
-     + Function COMBOBOXGETALLITEMS.
-     + Function COMBOBOXSELECTSTRING.
+  * core\include\i_combobox.ch
+    - Clause HSCROLL.
+    + Clause NOHSCROLL.
+    + Clause NOCLONE.
+      Set to .T. to allow the control to use the ITEMS array
+      without cloning it. Beware that the app may crash if
+      you mishandle the original array. Defaults to .F.
+  * core\include\i_altsyntax.ch
+    + Support for combobox clauses NOHSCROLL and NOCLONE.
+  * core\source\h_combobox.prg
+    * Parameter lHScroll of method Define replace by lNoHScroll.
+      Combo's horizontal text scrolling is now the default
+      behaviour. Add NOHSCROLL clause to get old behaviour.
+      INCOMPATIBLE.
+    - Data aRows from class TCombo.
+    + Data lNoClone to class TCombo.
+      Defaulfs to .F.
+    + Parameter lNoClose to method Define.
+    + Method GetItems to class TCombo.
+      Returns an array with all the items that are loaded in the
+      combobox. The array is build from the Windows' control.
+    + Method SelectString to class TCombo.
+      Searches the list for an item that begins with specified
+      string. If found, it's selected and copied to the display.
+    + Class TComboArray to handle ITEMS array as a database.
+    * Method ValueSource will now only return codeblocks.
+    * Methods Rows, Refresh, ReadData and DeleteAllItems were
+      adapted to work with class TComboArray.
+    * Removed length limit from function COMBOGETSTRING.
+    + Function COMBOBOXGETALLITEMS.
+    + Function COMBOBOXSELECTSTRING.
 
 2019-11-11 19:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     ! App is not ended after releasing MAIN window.
+  * core\source\h_form.prg
+    ! App is not ended after releasing MAIN window.
 
 2019-11-10 22:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-11-10 22:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_combo.ch
-     + Data aRows to class TCombo.
-     * Data ItemNumber of class TCombo renamed as ItemImgNum
-       for clarity. INCOMPATIBLE
-     - Data WorkArea of class TCombo.
-     + Data oWorkArea to class TCombo
-     + Data uWorkArea to class TCombo.
-     + Method ReadData to class TCombo.
-     + Method Rows to class TCombo.
-     + Method WorkArea to class TCombo.
-     - Now longer needed calls to OSisWinXPorLater().
-     * ITEMSOURCE now accepts a not qualified fieldname
-       if it belongs to the current workarea.
-     * ITEMSOURCE now accepts a codeblock.
-     + Support for data sources compatible with class OOHGRecord.
-     + Support for delayed-loading of items from array.
-     ! Method ValueSource of class TCombo when the parameter is
-       an array.
-     ! Return value of method VisibleItems of class TCombo.
-     * TEditCombo and TListCombo are now longer STATIC.
+  * core\source\h_combo.ch
+    + Data aRows to class TCombo.
+    * Data ItemNumber of class TCombo renamed as ItemImgNum
+      for clarity. INCOMPATIBLE
+    - Data WorkArea of class TCombo.
+    + Data oWorkArea to class TCombo
+    + Data uWorkArea to class TCombo.
+    + Method ReadData to class TCombo.
+    + Method Rows to class TCombo.
+    + Method WorkArea to class TCombo.
+    - Now longer needed calls to OSisWinXPorLater().
+    * ITEMSOURCE now accepts a not qualified fieldname
+      if it belongs to the current workarea.
+    * ITEMSOURCE now accepts a codeblock.
+    + Support for data sources compatible with class OOHGRecord.
+    + Support for delayed-loading of items from array.
+    ! Method ValueSource of class TCombo when the parameter is
+      an array.
+    ! Return value of method VisibleItems of class TCombo.
+    * TEditCombo and TListCombo are now longer STATIC.
 
 2019-11-10 22:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_combobox.ch
-     + Clause IMAGES as a synonym of IMAGE.
+  * core\include\i_combobox.ch
+    + Clause IMAGES as a synonym of IMAGE.
 
 2019-11-10 21:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_controlmisc.c
-     * Function ImageFillParameter now forces cString to "" when
-       first item of pString is not a string.
+  * core\source\c_controlmisc.c
+    * Function ImageFillParameter now forces cString to "" when
+      first item of pString is not a string.
 
 2019-11-10 21:55 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     + Data lRefreshDataOnActivate.
-       Set to .F. (at ON INIT procedure ) to prevent executing
-       method RefreshData at form's activation. Defaults to .T.
+  * core\source\h_form.prg
+    + Data lRefreshDataOnActivate.
+      Set to .F. (at ON INIT procedure ) to prevent executing
+      method RefreshData at form's activation. Defaults to .T.
 
 2019-11-10 21:50 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_controlmisc.prg
-     * Some format.
-     * Data ImageList is always set to 0 by method ClearBitmaps.
+  * core\source\h_controlmisc.prg
+    * Some format.
+    * Data ImageList is always set to 0 by method ClearBitmaps.
 
 2019-11-10 21:47 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     * Some format.
+  * core\source\h_xbrowse.prg
+    * Some format.
 
 2019-11-08 20:37 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\README.md
-     * Updated.
+  * core\README.md
+    * Updated.
 
 2019-11-08 15:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_application.prg
-     ! _OOHG_Main is set to NIL when it's accessed without parameters.
+  * core\source\h_application.prg
+    ! _OOHG_Main is set to NIL when it's accessed without parameters.
 
 2019-11-04 19:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_combobox.ch
-     + Clause HSCROLL.
-   * core\include\oohg.h
-     + CBS_AUTOHSCROLL.
-   * core\source\h_combobox.prg
-     + Support for clause HSCROLL.
-   ; This enables combo's horizontal text scrolling.
+  * core\include\i_combobox.ch
+    + Clause HSCROLL.
+  * core\include\oohg.h
+    + CBS_AUTOHSCROLL.
+  * core\source\h_combobox.prg
+    + Support for clause HSCROLL.
+    ; This enables combo's horizontal text scrolling.
 
 2019-11-04 19:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_bcc.bat
-     ! Additional libs support.
+  * core\compile_bcc.bat
+    ! Additional libs support.
 
 2019-11-04 19:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     + Comment.
+  * core\source\c_winapimisc.c
+    + Comment.
 
 2019-11-04 19:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     + Method RemoveTransparency.
-     + Method SetBackgroundInvisible.
-     + Method SetTransparency.
+  * core\source\h_windows.prg
+    + Method RemoveTransparency.
+    + Method SetBackgroundInvisible.
+    + Method SetTransparency.
 
 2019-11-04 22:04 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-11-04 21:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.h
-     + Defines and includes common to almost all sources.
-     ; Windows minimum supported version is now XP.
-   * core\source\bostaurus.prg
-   * core\source\c_activex.c
-   * core\source\c_controlmisc.c
-   * core\source\c_cursor.c
-   * core\source\c_dialogs.c
-   * core\source\c_font.c
-   * core\source\c_gdiplus.c
-   * core\source\c_graph.c
-   * core\source\c_image.c
-   * core\source\c_media.c
-   * core\source\c_msgbox.c
-   * core\source\c_resource.c
-   * core\source\c_scrsaver.c
-   * core\source\c_winapimisc.c
-   * core\source\c_windows.c
-   * core\source\h_application.prg
-   * core\source\h_button.prg
-   * core\source\h_checkbox.prg
-   * core\source\h_combo.prg
-   * core\source\h_controlmisc.prg
-   * core\source\h_datepicker.prg
-   * core\source\h_dll.prg
-   * core\source\h_form.prg
-   * core\source\h_frame.prg
-   * core\source\h_grid.prg
-   * core\source\h_help.prg
-   * core\source\h_hotkey.prg
-   * core\source\h_hotkeybox.prg
-   * core\source\h_image.prg
-   * core\source\h_ini.prg
-   * core\source\h_init.prg
-   * core\source\h_internal.prg
-   * core\source\h_ipaddress.prg
-   * core\source\h_label.prg
-   * core\source\h_listbox.prg
-   * core\source\h_media.prg
-   * core\source\h_menu.prg
-   * core\source\h_monthcal.prg
-   * core\source\h_notify.prg
-   * core\source\h_pdf.prg
-   * core\source\h_picture.prg
-   * core\source\h_progressbar.prg
-   * core\source\h_progressmeter.prg
-   * core\source\h_radio.prg
-   * core\source\h_registry.prg
-   * core\source\h_report.prg
-   * core\source\h_richeditbox.prg
-   * core\source\h_scroll.prg
-   * core\source\h_scrollbutton.prg
-   * core\source\h_slider.prg
-   * core\source\h_spinner.prg
-   * core\source\h_splitbox.prg
-   * core\source\h_status.prg
-   * core\source\h_tab.prg
-   * core\source\h_textarray.prg
-   * core\source\h_textbox.prg
-   * core\source\h_timer.prg
-   * core\source\h_toolbar.prg
-   * core\source\h_tooltip.prg
-   * core\source\h_tree.prg
-   * core\source\h_windows.prg
-   * core\source\miniprint.prg
-   * core\source\winprint.prg
-     - Defines and includes that were moved to oohg.h
+  * core\include\oohg.h
+    + Defines and includes common to almost all sources.
+    ; Windows minimum supported version is now XP.
+  * core\source\bostaurus.prg
+  * core\source\c_activex.c
+  * core\source\c_controlmisc.c
+  * core\source\c_cursor.c
+  * core\source\c_dialogs.c
+  * core\source\c_font.c
+  * core\source\c_gdiplus.c
+  * core\source\c_graph.c
+  * core\source\c_image.c
+  * core\source\c_media.c
+  * core\source\c_msgbox.c
+  * core\source\c_resource.c
+  * core\source\c_scrsaver.c
+  * core\source\c_winapimisc.c
+  * core\source\c_windows.c
+  * core\source\h_application.prg
+  * core\source\h_button.prg
+  * core\source\h_checkbox.prg
+  * core\source\h_combo.prg
+  * core\source\h_controlmisc.prg
+  * core\source\h_datepicker.prg
+  * core\source\h_dll.prg
+  * core\source\h_form.prg
+  * core\source\h_frame.prg
+  * core\source\h_grid.prg
+  * core\source\h_help.prg
+  * core\source\h_hotkey.prg
+  * core\source\h_hotkeybox.prg
+  * core\source\h_image.prg
+  * core\source\h_ini.prg
+  * core\source\h_init.prg
+  * core\source\h_internal.prg
+  * core\source\h_ipaddress.prg
+  * core\source\h_label.prg
+  * core\source\h_listbox.prg
+  * core\source\h_media.prg
+  * core\source\h_menu.prg
+  * core\source\h_monthcal.prg
+  * core\source\h_notify.prg
+  * core\source\h_pdf.prg
+  * core\source\h_picture.prg
+  * core\source\h_progressbar.prg
+  * core\source\h_progressmeter.prg
+  * core\source\h_radio.prg
+  * core\source\h_registry.prg
+  * core\source\h_report.prg
+  * core\source\h_richeditbox.prg
+  * core\source\h_scroll.prg
+  * core\source\h_scrollbutton.prg
+  * core\source\h_slider.prg
+  * core\source\h_spinner.prg
+  * core\source\h_splitbox.prg
+  * core\source\h_status.prg
+  * core\source\h_tab.prg
+  * core\source\h_textarray.prg
+  * core\source\h_textbox.prg
+  * core\source\h_timer.prg
+  * core\source\h_toolbar.prg
+  * core\source\h_tooltip.prg
+  * core\source\h_tree.prg
+  * core\source\h_windows.prg
+  * core\source\miniprint.prg
+  * core\source\winprint.prg
+    - Defines and includes that were moved to oohg.h
 
 2019-11-04 21:39 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     * TApplication():Define() replaced by _OOHG_AppObject().
+  * core\source\h_windows.prg
+    * TApplication():Define() replaced by _OOHG_AppObject().
 
 2019-11-04 21:33 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile.bat
-   * core\source\makelib.bat
-     + Support for BCC 5.8.2
-     * XB flavor splitted into XB55 and XB58 for BCC 5.5.1 and
-       BCC 5.8.2 respectively.
+  * core\compile.bat
+  * core\source\makelib.bat
+    + Support for BCC 5.8.2
+    * XB flavor splitted into XB55 and XB58 for BCC 5.5.1 and
+      BCC 5.8.2 respectively.
 
 2019-11-04 21:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\makelib_bcc.bat
-     ! Label INFO not found.
+  * core\source\makelib_bcc.bat
+    ! Label INFO not found.
 
 2019-11-04 21:31 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\resources\CompileRes_mingw.bat
-   * core\resources\CompileRes_bcc.bat
-     + Support for HG_CCOMP envvar.
+  * core\resources\CompileRes_mingw.bat
+  * core\resources\CompileRes_bcc.bat
+    + Support for HG_CCOMP envvar.
 
 2019-11-04 21:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_app.ch
-   * core\include\i_font.ch
-   * core\include\i_pseudofunc.ch
-   * core\include\i_var.ch
-   * core\source\h_error.prg
-   * core\source\h_menu.prg
-   * core\source\h_print.prg
-     * TApplication():Define() replaced by _OOHG_AppObject().
-   * core\source\h_application.prg
-     - ClassVar oAppObj.
-     + Module static var oAppObj.
-     + Function _OOHG_AppObject. Returns oAppObj.
-     ; Previous changes reduced overhead caused by repeatedly
-       creation and destruction of TApplication objects just
-       for accessing the methods of the class.
-     * Destructor End() renamed as Destroy().
-     ! Method End() renamed as Procedure Destroy() to fix
-       xHarbour compile-time error.
-   * core\source\h_init.prg
-     + Exit procedure to release TApplication object.
+  * core\include\i_app.ch
+  * core\include\i_font.ch
+  * core\include\i_pseudofunc.ch
+  * core\include\i_var.ch
+  * core\source\h_error.prg
+  * core\source\h_menu.prg
+  * core\source\h_print.prg
+    * TApplication():Define() replaced by _OOHG_AppObject().
+  * core\source\h_application.prg
+    - ClassVar oAppObj.
+    + Module static var oAppObj.
+    + Function _OOHG_AppObject. Returns oAppObj.
+    ; Previous changes reduced overhead caused by repeatedly
+      creation and destruction of TApplication objects just
+      for accessing the methods of the class.
+    * Destructor End() renamed as Destroy().
+    ! Method End() renamed as Procedure Destroy() to fix
+      xHarbour compile-time error.
+  * core\source\h_init.prg
+    + Exit procedure to release TApplication object.
 
 2019-11-04 21:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_combo.prg
-     * Two calls to GetWindowLong replace by GetWindowLongPtr.
+  * core\source\h_combo.prg
+    * Two calls to GetWindowLong replace by GetWindowLongPtr.
 
 2019-11-04 21:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_controlmisc.ch
-     - Redefinition of EXIT PROCEDURE command.
-     ; Now OOHG supports EXIT PROCEDUREs.
+  * core\include\i_controlmisc.ch
+    - Redefinition of EXIT PROCEDURE command.
+    ; Now OOHG supports EXIT PROCEDUREs.
 
 2019-11-04 21:23 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_tab.prg
-     + Method AdjustRect to class TTabRaw.
+  * core\source\h_tab.prg
+    + Method AdjustRect to class TTabRaw.
 
 2019-11-04 21:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     ! RTE at _OOHG_CallDump() when TApplication object doesn't
-       exists.
+  * core\source\h_windows.prg
+    ! RTE at _OOHG_CallDump() when TApplication object doesn't
+      exists.
 
 2019-11-04 21:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! Compilation under BCC 5.8.2
+  * core\source\h_grid.prg
+    ! Compilation under BCC 5.8.2
 
 2019-11-04 21:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.prg
-     + Compatibility function GetWindowLong.
+  * core\source\c_winapimisc.prg
+    + Compatibility function GetWindowLong.
 
 2019-11-04 21:20 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     ! Method Destroy() renamed as Procedure Destroy() to fix
-       xHarbour compile-time error.
+  * core\source\winprint.prg
+    ! Method Destroy() renamed as Procedure Destroy() to fix
+      xHarbour compile-time error.
 
 2019-11-04 21:19 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_window.ch
-     ! RELEASE WINDOW ALL.
-       ; The old behavior was restored: app is ended
-         using ExitProcess().
-     * RELEASE WINDOW MAIN.
-       ; Releases the Main window if it's defined.
-         If not defaults to RELEASE WINDOW ALL.
-   * core\source\h_form.prg
-     + Parameter lExit to function ReleaseAllWindows.
-       See comment at 2019-11-01 21:22 UTC-0300.
+  * core\include\i_window.ch
+    ! RELEASE WINDOW ALL.
+    ; The old behavior was restored: app is ended
+      using ExitProcess().
+    * RELEASE WINDOW MAIN.
+    ; Releases the Main window if it's defined.
+      If not defaults to RELEASE WINDOW ALL.
+  * core\source\h_form.prg
+    + Parameter lExit to function ReleaseAllWindows.
+      See comment at 2019-11-01 21:22 UTC-0300.
 
 2019-11-02 16:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\miniprint.ch
-   * core\source\h_print.prg
-   * core\source\miniprint.prg
-     ! Page preview disapears after initial load when
-       clause NOWAIT is added to END PRINTDOC.
+  * core\include\miniprint.ch
+  * core\source\h_print.prg
+  * core\source\miniprint.prg
+    ! Page preview disapears after initial load when
+      clause NOWAIT is added to END PRINTDOC.
 
 2019-11-01 21:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_app.ch
-     + App.Release
-   * core\include\i_var.ch
-   * core\source\h_application.prg
-   * core\source\h_form.prg
-   * core\source\h_init.prg
-     - Global var _OOHG_KeepAppOnMainRelease.
-   ; Now OOHG doesn't releases the TApplication object after
-     executing ReleaseAllWindows( lExit ) when lExit is not
-     a logical value or it's .F.
-   ; To unload the object you must place a call to
-     App.Release after ACTIVATE WINDOW "main".
-   ; Note that executing App.Release at other places will
-     throw an RTE.
-     See samples\form\s015.prg
+  * core\include\i_app.ch
+    + App.Release
+  * core\include\i_var.ch
+  * core\source\h_application.prg
+  * core\source\h_form.prg
+  * core\source\h_init.prg
+    - Global var _OOHG_KeepAppOnMainRelease.
+  ; Now OOHG doesn't releases the TApplication object after
+    executing ReleaseAllWindows( lExit ) when lExit is not
+    a logical value or it's .F.
+  ; To unload the object you must place a call to
+    App.Release after ACTIVATE WINDOW "main".
+  ; Note that executing App.Release at other places will
+    throw an RTE.
+    See samples\form\s015.prg
 
 2019-10-31 20:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-10-31 20:06 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     * _OOHG_ExitOnMainRelease is forced to .F.
-     * _OOHG_KeepAppOnMainRelease is forced to .T.
-     ; These enable the execution of destructors after
-       releasing the main window.
+  * core\source\h_init.prg
+    * _OOHG_ExitOnMainRelease is forced to .F.
+    * _OOHG_KeepAppOnMainRelease is forced to .T.
+    ; These enable the execution of destructors after
+      releasing the main window.
 
 2019-10-31 20:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_windefs.ch
-     + Define for WM_MOUSEHWHEEL.
-   * core\include\oohg.h
-     + Define for s_RangeWidth.
-   * core\source\c_controlmisc.c
-     + RANGEWIDTH to s_SymbolNames.
-   * core\source\h_form.prg
-     + WM_MOUSEHWHEEL to method Events of class TForm.
-     - Unneeded call to ReleaseAllWindows() at method Release
-       of class TFormMain.
-     * Function InitDummy now returns the window's handle.
+  * core\include\i_windefs.ch
+    + Define for WM_MOUSEHWHEEL.
+  * core\include\oohg.h
+    + Define for s_RangeWidth.
+  * core\source\c_controlmisc.c
+    + RANGEWIDTH to s_SymbolNames.
+  * core\source\h_form.prg
+    + WM_MOUSEHWHEEL to method Events of class TForm.
+    - Unneeded call to ReleaseAllWindows() at method Release
+      of class TFormMain.
+    * Function InitDummy now returns the window's handle.
 
 2019-10-31 20:01 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_application.prg
-     + Destructor.
-     ! RTE "not an array" at method Release.
+  * core\source\h_application.prg
+    + Destructor.
+    ! RTE "not an array" at method Release.
 
 2019-10-31 19:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     - Unneeded code.
+  * core\source\winprint.prg
+    - Unneeded code.
 
 2019-10-30 17:09 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_picture.prg
-     ! Control shows no image.
-     * Function _OOHG_TPicture_Register renamed to
-       _OOHG_PictureControl_Register.
-     * Function _OOHG_TPicture_UnRegister renamed to
-       _OOHG_PictureControl_UnRegister.
-     * Function _OOHG_TPicture_lpfnOldWndProc renamed to
-       _OOHG_PictureControl_lpfnOldWndProc.
-     * Function _OOHG_TPicture_WndProc renamed to
-       _OOHG_PictureControl_WndProc.
-     * Function _OOHG_TPicture_WndProc renamed to
-       _OOHG_PictureControl_WndProc.
-   * core\source\h_application.prg
-     * Call to _OOHG_TPicture_UnRegister replaced by
-       _OOHG_PictureControl_UnRegister.
+  * core\source\h_picture.prg
+    ! Control shows no image.
+    * Function _OOHG_TPicture_Register renamed to
+      _OOHG_PictureControl_Register.
+    * Function _OOHG_TPicture_UnRegister renamed to
+      _OOHG_PictureControl_UnRegister.
+    * Function _OOHG_TPicture_lpfnOldWndProc renamed to
+      _OOHG_PictureControl_lpfnOldWndProc.
+    * Function _OOHG_TPicture_WndProc renamed to
+      _OOHG_PictureControl_WndProc.
+    * Function _OOHG_TPicture_WndProc renamed to
+      _OOHG_PictureControl_WndProc.
+  * core\source\h_application.prg
+    * Call to _OOHG_TPicture_UnRegister replaced by
+      _OOHG_PictureControl_UnRegister.
 
 2019-10-30 17:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_scroll.prg
-     ! Return value of method Events_VScroll of class TScrollBar.
+  * core\source\h_scroll.prg
+    ! Return value of method Events_VScroll of class TScrollBar.
 
 2019-10-30 17:05 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\winprint.ch
-     + Clause FOLDER to INIT PRINTSYS command.
-       It allows to set the folder for temp files.
-   * core\source\winprint.prg
-     * Some format.
-     + Some defines to improve source readability.
-     + Destructor to class HBPrinter.
-     - Method PrevAdjust.
-     + Parameter cFolder to method New of class HBPrinter.
-     ! Method End of class HBPrinter generates a RTE when
-       printer handle or job handle are not defined.
-     ! Thumbnails are not visible after resizing the splitbox
-       panel.
-     * Label "Go To Page" replaced by combobox's grippertext.
-     * Combobox "Go To Page" now allows to enter the number
-       of a page.
-     ! "Go To Page" label and combo disappear after resizing
-       the preview window.
+  * core\include\winprint.ch
+    + Clause FOLDER to INIT PRINTSYS command.
+      It allows to set the folder for temp files.
+  * core\source\winprint.prg
+    * Some format.
+    + Some defines to improve source readability.
+    + Destructor to class HBPrinter.
+    - Method PrevAdjust.
+    + Parameter cFolder to method New of class HBPrinter.
+    ! Method End of class HBPrinter generates a RTE when
+      printer handle or job handle are not defined.
+    ! Thumbnails are not visible after resizing the splitbox
+      panel.
+    * Label "Go To Page" replaced by combobox's grippertext.
+    * Combobox "Go To Page" now allows to enter the number
+      of a page.
+    ! "Go To Page" label and combo disappear after resizing
+      the preview window.
 
 2019-10-30 17:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_combo.prg
-     * Method Events_Enter to class TEditCombo.
-     ! Enter key doesn't change the combobox value.
+  * core\source\h_combo.prg
+    * Method Events_Enter to class TEditCombo.
+    ! Enter key doesn't change the combobox value.
 
 2019-10-30 17:01 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_toolbar.ch
-   * core\source\h_toolbar.prg
-     + Clause TOOLBARSIZE.
-       ; It allows to set the ideal size.
-   * core\source\h_windows.prg
-     + Parameter idealsize to method SetSplitBoxInfo of class TWindow.
-   * core\source\h_splitbox.prg
-     + Data nIdealSize.
-     * Some format.
-     + Parameter idealsize to functions AddSplitBoxItem and
-       SetSplitBoxItem and to method SetSplitBox.
-     + Reset code to method AddControl.
+  * core\include\i_toolbar.ch
+  * core\source\h_toolbar.prg
+    + Clause TOOLBARSIZE.
+    ; It allows to set the ideal size.
+  * core\source\h_windows.prg
+    + Parameter idealsize to method SetSplitBoxInfo of class TWindow.
+  * core\source\h_splitbox.prg
+    + Data nIdealSize.
+    * Some format.
+    + Parameter idealsize to functions AddSplitBoxItem and
+      SetSplitBoxItem and to method SetSplitBox.
+    + Reset code to method AddControl.
 
 2019-10-24 18:33 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_browse.prg
-     * On init the disabled style is deferred until the control
-       is populated.
-     * Return Self changed to NIL for non constructor methods.
-     * Some format.
-     ! Vertical scrollbar remains operative after disabling
-       the control.
+  * core\source\h_browse.prg
+    * On init the disabled style is deferred until the control
+      is populated.
+    * Return Self changed to NIL for non constructor methods.
+    * Some format.
+    ! Vertical scrollbar remains operative after disabling
+      the control.
 
 2019-10-24 18:33 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     * On init the disabled style is deferred until the control
-       is populated.
-     ! Vertical scrollbar remains operative after disabling
-       the control.
-     * Method Enabled of class TOBrowse now disables the
-       vertical scrollbar.
+  * core\source\h_xbrowse.prg
+    * On init the disabled style is deferred until the control
+      is populated.
+    ! Vertical scrollbar remains operative after disabling
+      the control.
+    * Method Enabled of class TOBrowse now disables the
+      vertical scrollbar.
 
 2019-10-24 18:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     * On init the disabled style is deferred until the control
-       is populated.
+  * core\source\h_grid.prg
+    * On init the disabled style is deferred until the control
+      is populated.
 
 2019-10-24 18:31 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\oohg.hbc
-     * Lib xhb was moved to last position in link order.
+  * core\oohg.hbc
+    * Lib xhb was moved to last position in link order.
 
 2019-10-24 18:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_bcc.bat
-     * HG_CCOMP replaced by HG_BCC.
-     ! Missing init values of some envvars.
-     + Define for _OOHG_CONSOLEMODE_ when /C switch is used.
-       This define is passed to every exe in the tool chain.
-     * Some local envvars were renamed.
-     * Lib xhb was moved to last position in link order.
-     ! Harbour based builds.
+  * core\compile_bcc.bat
+    * HG_CCOMP replaced by HG_BCC.
+    ! Missing init values of some envvars.
+    + Define for _OOHG_CONSOLEMODE_ when /C switch is used.
+      This define is passed to every exe in the tool chain.
+    * Some local envvars were renamed.
+    * Lib xhb was moved to last position in link order.
+    ! Harbour based builds.
 
 2019-10-24 18:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_MINGW.BAT
-     * HG_CCOMP replaced by HG_MING.
-     + Define for _OOHG_CONSOLEMODE_ when /C switch is used.
-       This define is passed to every exe in the tool chain.
-     * Removed support for THR_LIB envvar.
-       Use HG_ADDLIBS instead.
-       INCOMPATIBLE.
-     * Some local envvars were renamed.
-     * Lib xhb was moved to last position in link order.
+  * core\compile_MINGW.BAT
+    * HG_CCOMP replaced by HG_MING.
+    + Define for _OOHG_CONSOLEMODE_ when /C switch is used.
+      This define is passed to every exe in the tool chain.
+    * Removed support for THR_LIB envvar.
+      Use HG_ADDLIBS instead.
+      INCOMPATIBLE.
+    * Some local envvars were renamed.
+    * Lib xhb was moved to last position in link order.
 
 2019-10-24 18:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile.bat
-     ! Missing init values of some envvars.
-     + HG_FLAVOR envvar.
+  * core\compile.bat
+    ! Missing init values of some envvars.
+    + HG_FLAVOR envvar.
 
 2019-10-24 18:27 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimsc.c
-     * Some BCC 5.8.2 warnings were pacified.
-     - Unneeded code.
+  * core\source\c_winapimsc.c
+    * Some BCC 5.8.2 warnings were pacified.
+    - Unneeded code.
 
 2019-10-24 18:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     - Duplicated statement.
+  * core\source\h_init.prg
+    - Duplicated statement.
 
 2019-10-24 18:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_menu.prg
-     ! Method Enabled of class TMenu.
-     ! Method Enabled of class TMenuItem.
+  * core\source\h_menu.prg
+    ! Method Enabled of class TMenu.
+    ! Method Enabled of class TMenuItem.
 
 2019-10-24 18:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_notify.prg
-     - Some comments.
+  * core\source\h_notify.prg
+    - Some comments.
 
 2019-10-24 18:24 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-     ! Clause ONMDBLCLICK.
+  * core\include\i_altsyntax.ch
+    ! Clause ONMDBLCLICK.
 
 2019-10-24 18:23 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     + Parameter lCurrent to function _OOHG_CallDump.
-       When it's .T. only the last called function will be dumped.
-       Defaults to .F.
-     * The name of the log is now configurable.
-     - Debug code left behind in the previous commit.
+  * core\source\h_windows.prg
+    + Parameter lCurrent to function _OOHG_CallDump.
+      When it's .T. only the last called function will be dumped.
+      Defaults to .F.
+    * The name of the log is now configurable.
+    - Debug code left behind in the previous commit.
 
 2019-10-24 18:22 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_app.ch
-   * core\include\i_var.ch
-   * core\source\h_application.prg
-     + Support for _OOHG_LogFile var.
-     + SET LOGFILE TO.
+  * core\include\i_app.ch
+  * core\include\i_var.ch
+  * core\source\h_application.prg
+    + Support for _OOHG_LogFile var.
+    + SET LOGFILE TO.
 
 2019-10-24 18:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-   * core\include\miniprint.ch
-     + The possibility to hide the Save button.
+  * core\source\miniprint.prg
+  * core\include\miniprint.ch
+    + The possibility to hide the Save button.
 
 2019-10-24 18:20 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     + The possibility to choose a folder for saving to.
+  * core\source\winprint.prg
+    + The possibility to choose a folder for saving to.
 
 2019-10-18 18:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     ! Method StartDoc doesn't honor the value of ::DocName.
+  * core\source\winprint.prg
+    ! Method StartDoc doesn't honor the value of ::DocName.
 
 2019-10-16 20:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     * Fixed font name and size at function InputBox replaced by
-       _OOHG_DefaultFontName and _OOHG_DefaultFontSize.
+  * core\source\h_windows.prg
+    * Fixed font name and size at function InputBox replaced by
+      _OOHG_DefaultFontName and _OOHG_DefaultFontSize.
 
 2019-10-16 18:12 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\bostaurus_dyns.hbx
-   * core\include\hbprinter_dyns.hbx
-   * core\include\miniprint_dyns.hbx
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\bostaurus_dyns.hbx
+  * core\include\hbprinter_dyns.hbx
+  * core\include\miniprint_dyns.hbx
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-10-16 19:12 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-     * Some MinGW CLang warnings were pacified.
+  * core\source\miniprint.prg
+    * Some MinGW CLang warnings were pacified.
 
 2019-10-16 19:06 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_richeditbox.prg
-     * Some MinGW CLang warnings were pacified.
+  * core\source\h_richeditbox.prg
+    * Some MinGW CLang warnings were pacified.
 
 2019-10-16 19:04 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimsc.c
-     * Some BCC warnings were pacified.
+  * core\source\c_winapimsc.c
+    * Some BCC warnings were pacified.
 
 2019-10-15 18:12 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     + DATA lReportError. Set to .T. to show printer configuration
-       errors. Defaults to .F.
-     * Method SetDevMode now handles printer configuration errors
-       and returns .T./.F. on success/failure.
-     + Some messages to language arrays.
-     ! Division by zero at method PrevShow().
+  * core\source\winprint.prg
+    + DATA lReportError. Set to .T. to show printer configuration
+      errors. Defaults to .F.
+    * Method SetDevMode now handles printer configuration errors
+      and returns .T./.F. on success/failure.
+    + Some messages to language arrays.
+    ! Division by zero at method PrevShow().
 
 2019-10-13 10:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_radio.ch
-     + Clause LIMIT. Sets the maximum number of items per column
-       (for 'vertical' radiogroups) or row (for 'horizontal' ones).
-       This allows to create 'multiline' radiogroups.
-       Setting limit to 0 disables 'multiline' effect.
-     + Clause SHIFT.
-   * core\source\h_radio.prg
-     + Data nLimit.
-     + Data nShift.
-     + Method Limit.
-     + Method Shift.
-     + Method RePaint.
-     ; Note that methods Limit, Shift, Spacing and RePaint redraw
-       the entire control thus discarding any manually change made
-       to an item's row, col, width and height properties.
-     * Method InsertItem now accepts parameters nCol, nRow, nWidth
-       and nHeight to enable customized items without redrawing
-       the whole control.
-     * Method DeleteItem now accepts lRePaint to force the control
-       repaint after deleting an item.
-     ! Control is not painted properly after window's resize when
-       AUTOADJUST is ON.
-   ; Notes on properties:
-     HEIGHT is the height of each individual item.
-     WIDTH is the width of each individual item.
-     For a 'vertical' radiogroup:
-     - SPACING is the vertical distance between two adjacent rows.
-     - SHIFT is the horizontal distance between two adjacent columns.
-     For a 'horizontal' radiogroup:
-     - SPACING is the horizontal distance between two adjacent columns.
-     - SHIFT is the horizontal distance between two adjacent rows.
+  * core\include\i_radio.ch
+    + Clause LIMIT. Sets the maximum number of items per column
+      (for 'vertical' radiogroups) or row (for 'horizontal' ones).
+      This allows to create 'multiline' radiogroups.
+      Setting limit to 0 disables 'multiline' effect.
+    + Clause SHIFT.
+  * core\source\h_radio.prg
+    + Data nLimit.
+    + Data nShift.
+    + Method Limit.
+    + Method Shift.
+    + Method RePaint.
+    ; Note that methods Limit, Shift, Spacing and RePaint redraw
+      the entire control thus discarding any manually change made
+      to an item's row, col, width and height properties.
+    * Method InsertItem now accepts parameters nCol, nRow, nWidth
+      and nHeight to enable customized items without redrawing
+      the whole control.
+    * Method DeleteItem now accepts lRePaint to force the control
+      repaint after deleting an item.
+    ! Control is not painted properly after window's resize when
+      AUTOADJUST is ON.
+    ; Notes on properties:
+      HEIGHT is the height of each individual item.
+      WIDTH is the width of each individual item.
+      For a 'vertical' radiogroup:
+      SPACING is the vertical distance between two adjacent rows.
+      SHIFT is the horizontal distance between two adjacent columns.
+      For a 'horizontal' radiogroup:
+      SPACING is the horizontal distance between two adjacent columns.
+      SHIFT is the horizontal distance between two adjacent rows.
 
 2019-10-11 17:59 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_radio.prg
-     ! Methods GroupHeight and GroupWidth not always return the right
-       height and width when an item was placed manually. Now they
-       return the height and width of the rectangle that encloses all
-       the radiogroup's items.
+  * core\source\h_radio.prg
+    ! Methods GroupHeight and GroupWidth not always return the right
+      height and width when an item was placed manually. Now they
+      return the height and width of the rectangle that encloses all
+      the radiogroup's items.
 
 2019-10-10 20:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     * Comment.
+  * core\source\h_windows.prg
+    * Comment.
 
 2019-10-10 20:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_windefs.ch
-     + HDN_ITEMDBLCLICK.
-   * core\include\i_altsyntax.ch
-   * core\include\i_grid.ch
-   * core\include\i_browse.ch
-   * core\include\i_xbrowse.ch
-     + Clause ON HEADDBLCLICK.
-   * core\source\h_grid.prg
-   * core\source\h_browse.prg
-   * core\source\h_xbrowse.prg
-     + Support for ON HEADDBLCLICK event.
+  * core\include\i_windefs.ch
+    + HDN_ITEMDBLCLICK.
+  * core\include\i_altsyntax.ch
+  * core\include\i_grid.ch
+  * core\include\i_browse.ch
+  * core\include\i_xbrowse.ch
+    + Clause ON HEADDBLCLICK.
+  * core\source\h_grid.prg
+  * core\source\h_browse.prg
+  * core\source\h_xbrowse.prg
+    + Support for ON HEADDBLCLICK event.
 
 2019-10-09 17:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! ::nDelayedClick initialization.
+  * core\source\h_grid.prg
+    ! ::nDelayedClick initialization.
 
 2019-10-09 17:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_MINGW.BAT
-     ! Console compilation.
+  * core\compile_MINGW.BAT
+    ! Console compilation.
 
 2019-10-08 22:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_altsyntax.ch
-     + Support for clauses added since last update.
-     * ! value -> ! ( value )
-     ! RichEditBox's FILETYPE clause.
+  * core\include\i_altsyntax.ch
+    + Support for clauses added since last update.
+    * ! value -> ! ( value )
+    ! RichEditBox's FILETYPE clause.
 
 2019-10-07 20:14 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     ! Function _OOHG_NESTEDSAMEEVENT is not setting the flag
-       to .T. thus preventing nested clicks on toolbar buttons.
+  * core\source\h_windows.prg
+    ! Function _OOHG_NESTEDSAMEEVENT is not setting the flag
+      to .T. thus preventing nested clicks on toolbar buttons.
 
 2019-10-07 20:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_windows.c
-     * Function ShowLastError now return the error code.
-     * Function _OOHG_DOMESSAGELOOP now checks the return value of
-       GetMessage() and if it's -1 shows a message and ends the app.
+  * core\source\c_windows.c
+    * Function ShowLastError now return the error code.
+    * Function _OOHG_DOMESSAGELOOP now checks the return value of
+      GetMessage() and if it's -1 shows a message and ends the app.
 
 2019-10-07 20:01 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_richeditbox.ch
-     + Clause VERSION <number> where number is 30 for older versions
-       of the control (class RICHEDIT_CLASS from RICHEDIT20.dll) or
-       41 for newer versions (class MSFTEDIT_CLASS from Msftedit.dll).
-       Defaults to 41 if present or to 30 if not.
-   * core\source\h_richeditbox.prg
-     + DATA Version.
-     + New parameter to method Define and function InitRichEditBox.
-     + Logic handle both versions at function InitRichEditBox.
+  * core\include\i_richeditbox.ch
+    + Clause VERSION <number> where number is 30 for older versions
+      of the control (class RICHEDIT_CLASS from RICHEDIT20.dll) or
+      41 for newer versions (class MSFTEDIT_CLASS from Msftedit.dll).
+      Defaults to 41 if present or to 30 if not.
+  * core\source\h_richeditbox.prg
+    + DATA Version.
+    + New parameter to method Define and function InitRichEditBox.
+    + Logic handle both versions at function InitRichEditBox.
 
 2019-10-06 21:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     - No longer needed memvar declarations at module level.
-     * DATA lIgnorePropertyError is no longer READONLY.
-     * DATA lNoErrMsg is no longer READONLY.
-     + Language parameter to methods Init and SelPrinter of
-       class TPrint. This parameter is only supported by methods
-       InitX and SelPrinterX of subclasses TMiniPrint and THBPrinter.
-     * Landscape orientation is no longer forced to .F. for clasess
-       TMiniPrint and THBPrinter. If this parameter is omitted then
-       the printer's current value will be used.
-     ! Methods MaxRow, MaxCol and IsDocOpenX of class TMiniPrint.
-     * Public vars at method InitX of class TMiniPrint were replaced
-       by a call to function _HMG_PRINTER_InitUserMessages.
-     ! Typo in var name.
-     ! Value of DATA lLandscape of class TPrint.
-     - DATA cPageOrient of class TPdfPrint.
+  * core\source\h_print.prg
+    - No longer needed memvar declarations at module level.
+    * DATA lIgnorePropertyError is no longer READONLY.
+    * DATA lNoErrMsg is no longer READONLY.
+    + Language parameter to methods Init and SelPrinter of
+      class TPrint. This parameter is only supported by methods
+      InitX and SelPrinterX of subclasses TMiniPrint and THBPrinter.
+    * Landscape orientation is no longer forced to .F. for clasess
+      TMiniPrint and THBPrinter. If this parameter is omitted then
+      the printer's current value will be used.
+    ! Methods MaxRow, MaxCol and IsDocOpenX of class TMiniPrint.
+    * Public vars at method InitX of class TMiniPrint were replaced
+      by a call to function _HMG_PRINTER_InitUserMessages.
+    ! Typo in var name.
+    ! Value of DATA lLandscape of class TPrint.
+    - DATA cPageOrient of class TPdfPrint.
 
 2019-10-06 21:34 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\miniprint_dyns.hbx
-     * Updated.
-   * core\resources\oohg.rc
-     + Comment explaining how to override MiniPrint hardwired messages.
-       This is intended to be a quick fix for bad messages.
-       If you find one, please open an issue.
-   * core\include\miniprint.ch
-     + ifndef to avoid compiler error caused by duplicated defines.
-     + Translates for _HMG_PRINTER_* variables.
-     + Support for language setting to SELECT PRINTER commands.
-     + Alignment options to PRINT DATA command.
-     + Some commands and options to support some HMG Extended features.
-     + Defines for brush styles, text alignment, and printer
-       status codes.
-   * core\source\miniprint.prg
-     * _HMG_PRINTER_* public vars were replaced by _HMG_MiniPrint array.
-     * Prefix _OOHG of var and form names replace by _HMG_PRINTER.
-     + Support for language setting to function _HMG_PRINTER_GetPrinter.
-     + Support for alignment to functions _HMG_PRINTER_H_Print,
-       _HMG_PRINTER_H_MultiLine_Print and _HMG_PRINTER_C_MULTILINE_PRINT.
-     + Support for NOPEN and NOBRUSH to functions _HMG_PRINTER_H_Pie,
-       _HMG_PRINTER_H_Ellipse, _HMG_PRINTER_H_Rectangle,
-       _HMG_PRINTER_C_RECTANGLE, _HMG_PRINTER_C_ROUNDRECTANGLE,
-       _HMG_PRINTER_H_RoundRectangle, _HMG_PRINTER_C_ELLIPSE and
-       _HMG_PRINTER_C_PIE.
-     + Error messages to language arrays.
-     + Function _HMG_PRINTER_InitUserMessages now has the ability to
-       load the strings from the resource file. This strings will
-       override the default ones. See oohg.rc
-     + Functions _HMG_PRINTER_GetJobInfo and _HMG_PRINTER_C_GETJOBINFO.
-     + Function _HMG_PRINTER_GetStatus and _HMG_PRINTER_C_GETSTATUS.
-     * Functions _HMG_PRINTER_SetPrinterProperties,
-       _HMG_PRINTER_C_SETPRINTERPROPERTIES and _HMG_PRINTER_PRINTDIALOG
-       now return a 14-item array, enabling access to all the printer
-       driver properties.
-     + Function _HMG_PRINTER_SETCHARSET.
-     + Function _HMG_PRINTER_GETTEXTALIGN.
-     + Function _HMG_PRINTER_STARTDOC now returns the print job
-       identifier (numeric) on success or 0 on failure.
-     + Charset support.
-     ! Function _HMG_PRINTER_C_SETPRINTERPROPERTIES fails to change
-       more than one printer driver's property at a time.
-     ! Return value of function _HMG_PRINTER_STARTPAGE_PREVIEW.
-     * Functions _HMG_PRINTER_ENDDOC, _HMG_PRINTER_STARTPAGE and
-       _HMG_PRINTER_ENDPAGE now return .T./.F. on success/failure.
-   ; Now OOHG supports the same features as HMG Extended.
+  * core\include\miniprint_dyns.hbx
+    * Updated.
+  * core\resources\oohg.rc
+    + Comment explaining how to override MiniPrint hardwired messages.
+      This is intended to be a quick fix for bad messages.
+      If you find one, please open an issue.
+  * core\include\miniprint.ch
+    + ifndef to avoid compiler error caused by duplicated defines.
+    + Translates for _HMG_PRINTER_* variables.
+    + Support for language setting to SELECT PRINTER commands.
+    + Alignment options to PRINT DATA command.
+    + Some commands and options to support some HMG Extended features.
+    + Defines for brush styles, text alignment, and printer
+      status codes.
+  * core\source\miniprint.prg
+    * _HMG_PRINTER_* public vars were replaced by _HMG_MiniPrint array.
+    * Prefix _OOHG of var and form names replace by _HMG_PRINTER.
+    + Support for language setting to function _HMG_PRINTER_GetPrinter.
+    + Support for alignment to functions _HMG_PRINTER_H_Print,
+      _HMG_PRINTER_H_MultiLine_Print and _HMG_PRINTER_C_MULTILINE_PRINT.
+    + Support for NOPEN and NOBRUSH to functions _HMG_PRINTER_H_Pie,
+      _HMG_PRINTER_H_Ellipse, _HMG_PRINTER_H_Rectangle,
+      _HMG_PRINTER_C_RECTANGLE, _HMG_PRINTER_C_ROUNDRECTANGLE,
+      _HMG_PRINTER_H_RoundRectangle, _HMG_PRINTER_C_ELLIPSE and
+      _HMG_PRINTER_C_PIE.
+    + Error messages to language arrays.
+    + Function _HMG_PRINTER_InitUserMessages now has the ability to
+      load the strings from the resource file. This strings will
+      override the default ones. See oohg.rc
+    + Functions _HMG_PRINTER_GetJobInfo and _HMG_PRINTER_C_GETJOBINFO.
+    + Function _HMG_PRINTER_GetStatus and _HMG_PRINTER_C_GETSTATUS.
+    * Functions _HMG_PRINTER_SetPrinterProperties,
+      _HMG_PRINTER_C_SETPRINTERPROPERTIES and _HMG_PRINTER_PRINTDIALOG
+      now return a 14-item array, enabling access to all the printer
+      driver properties.
+    + Function _HMG_PRINTER_SETCHARSET.
+    + Function _HMG_PRINTER_GETTEXTALIGN.
+    + Function _HMG_PRINTER_STARTDOC now returns the print job
+      identifier (numeric) on success or 0 on failure.
+    + Charset support.
+    ! Function _HMG_PRINTER_C_SETPRINTERPROPERTIES fails to change
+      more than one printer driver's property at a time.
+    ! Return value of function _HMG_PRINTER_STARTPAGE_PREVIEW.
+    * Functions _HMG_PRINTER_ENDDOC, _HMG_PRINTER_STARTPAGE and
+      _HMG_PRINTER_ENDPAGE now return .T./.F. on success/failure.
+    ; Now OOHG supports the same features as HMG Extended.
 
 2019-10-06 12:42 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-10-06 12:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\hbprinter_dyns.hbx
-     * Updated.
-   * core\resources\oohg.rc
-     + Comment explaining how to override HBPrinter hardwired messages.
-       This is intended to be a quick fix for bad messages.
-       If you find one, please open an issue.
-   * core\source\c_winapimsc.c
-     + Function LoadString.
-   * core\include\winprint.ch
-     + SET CLOSEPREVIEW ON|OFF commands.
-     + GET CLOSEPREVIEW TO command.
-     + GET ESCAPE STATUS TO command.
-     + Parameter validation to SET COPIES command.
-     + Optional PRINTER clause to SELECT commands.
-     + Optional LANGUAGE clause to INIT PRINTSYS command.
-     + SET PREVIEW RECT commands.
-     + SET USER PAPERSIZE commands.
-     + GET TEXT EXTENT IN MM command.
-     + ifndef to avoid compiler error caused by duplicated defines.
-   * core\source\winprint.prg
-     + DATA ClsPreview.
-     * DATA CurPage is now PROTECTED.
-     * DATA Error is now READONLY.
-     * DATA hDCRef is now PROTECTED.
-     * DATA MetaFiles is now PROTECTED.
-     * DATA PrintingEMF is now PROTECTED.
-     * DATA PrintOpt is now PROTECTED.
-     + DATA lEscaped.
-     + DATA Version.
-     + METHOD BasePageName.
-     + METHOD CleanOnPrevClose.
-     + METHOD GetTextExtent_MM.
-     + METHOD SetUserMode.
-     + METHOD Version.
-     * Some format.
-     ! Base folder for docs.
-     ! Variable initialization at method SelectPrinter.
-     ! Deletion of metafiles at method End.
-     - Unneeded code at method End.
-     * Number of pages is no longer limited to 9999.
-     + New messages.
-     * Preview window's size now takes into account the system
-       taskbar.
-     + NEXT, PRIOR and CTRL+P keys to preview window.
-     * Button Save has now a dropdown menu that allows to
-       save as and to save current page.
-     + Function RR_SETUSERMODE.
-     + Function RR_GETDESKTOPAREA.
-     * Method SaveMetaFiles moved to #ifndef NO_GUI section.
-     + Parameter filename to method SaveMetaFiles.
-     * The design of the Print Options window to allow more
-       room for labels.
-     + Method InitMessages now has the ability to load the
-       strings from the resource file. This strings will
-       override the default ones. See oohg.rc
-   ; Now OOHG supports the same features as HMG Extended.
+  * core\include\hbprinter_dyns.hbx
+    * Updated.
+  * core\resources\oohg.rc
+    + Comment explaining how to override HBPrinter hardwired messages.
+      This is intended to be a quick fix for bad messages.
+      If you find one, please open an issue.
+  * core\source\c_winapimsc.c
+    + Function LoadString.
+  * core\include\winprint.ch
+    + SET CLOSEPREVIEW ON|OFF commands.
+    + GET CLOSEPREVIEW TO command.
+    + GET ESCAPE STATUS TO command.
+    + Parameter validation to SET COPIES command.
+    + Optional PRINTER clause to SELECT commands.
+    + Optional LANGUAGE clause to INIT PRINTSYS command.
+    + SET PREVIEW RECT commands.
+    + SET USER PAPERSIZE commands.
+    + GET TEXT EXTENT IN MM command.
+    + ifndef to avoid compiler error caused by duplicated defines.
+  * core\source\winprint.prg
+    + DATA ClsPreview.
+    * DATA CurPage is now PROTECTED.
+    * DATA Error is now READONLY.
+    * DATA hDCRef is now PROTECTED.
+    * DATA MetaFiles is now PROTECTED.
+    * DATA PrintingEMF is now PROTECTED.
+    * DATA PrintOpt is now PROTECTED.
+    + DATA lEscaped.
+    + DATA Version.
+    + METHOD BasePageName.
+    + METHOD CleanOnPrevClose.
+    + METHOD GetTextExtent_MM.
+    + METHOD SetUserMode.
+    + METHOD Version.
+    * Some format.
+    ! Base folder for docs.
+    ! Variable initialization at method SelectPrinter.
+    ! Deletion of metafiles at method End.
+    - Unneeded code at method End.
+    * Number of pages is no longer limited to 9999.
+    + New messages.
+    * Preview window's size now takes into account the system
+      taskbar.
+    + NEXT, PRIOR and CTRL+P keys to preview window.
+    * Button Save has now a dropdown menu that allows to
+      save as and to save current page.
+    + Function RR_SETUSERMODE.
+    + Function RR_GETDESKTOPAREA.
+    * Method SaveMetaFiles moved to #ifndef NO_GUI section.
+    + Parameter filename to method SaveMetaFiles.
+    * The design of the Print Options window to allow more
+      room for labels.
+    + Method InitMessages now has the ability to load the
+      strings from the resource file. This strings will
+      override the default ones. See oohg.rc
+    ; Now OOHG supports the same features as HMG Extended.
 
 2019-10-06 12:18 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_windefs.ch
-     + Defines for richeditbox control.
-     + Defines for mouse related flags.
-   * core\include\i_richeditbox.ch
-     + Defines for methods LoadFile and SaveFile.
-   * core\source\h_richeditbox.prg
-     + Methods AutoURLDetect, CanPaste, CanReDo, GetSelType,
-       ReDo, SetOptions, SetSelEx and Value.
-     + Support for MS Rich Edit version 4.1
-     ! Wrong parameter declaration of functions EditStreamCallbackIn,
-       EditStreamCallbackOut, EditStreamCallbackFileIn and
-       EditStreamCallbackFileOut.
-     + Functions TEDITRICH_SETTEXT, TEDITRICH_SETOPTIONS,
-       TEDITRICH_SETSELEX and TEDITRICH_SELECTIONTYPE.
-   ; Now OOHG supports the same features as HMG Extended (note that
-     UNICODE is still missing).
+  * core\include\i_windefs.ch
+    + Defines for richeditbox control.
+    + Defines for mouse related flags.
+  * core\include\i_richeditbox.ch
+    + Defines for methods LoadFile and SaveFile.
+  * core\source\h_richeditbox.prg
+    + Methods AutoURLDetect, CanPaste, CanReDo, GetSelType,
+      ReDo, SetOptions, SetSelEx and Value.
+    + Support for MS Rich Edit version 4.1
+    ! Wrong parameter declaration of functions EditStreamCallbackIn,
+      EditStreamCallbackOut, EditStreamCallbackFileIn and
+      EditStreamCallbackFileOut.
+    + Functions TEDITRICH_SETTEXT, TEDITRICH_SETOPTIONS,
+      TEDITRICH_SETSELEX and TEDITRICH_SELECTIONTYPE.
+    ; Now OOHG supports the same features as HMG Extended (note that
+      UNICODE is still missing).
 
 2019-10-06 12:16 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_textbox.prg
-     + Methods CanUnDo, Clear, Copy, Cut, Paste, SetRect and UnDo.
-     + Function TTEXT_SETRECT.
+  * core\source\h_textbox.prg
+    + Methods CanUnDo, Clear, Copy, Cut, Paste, SetRect and UnDo.
+    + Function TTEXT_SETRECT.
 
 2019-10-06 12:15 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     + Some messages.
-     + Functions InitMessages_C_Side and _OOHG_Msg to allow access
-       to message arrays from C-side functions.
-     ; Added for future use.
+  * core\source\h_init.prg
+    + Some messages.
+    + Functions InitMessages_C_Side and _OOHG_Msg to allow access
+      to message arrays from C-side functions.
+    ; Added for future use.
 
 2019-10-06 12:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_media.prg
+  * core\source\h_media.prg
     * The code to end the app when the initialization of the controls
       fails was moved to the PRG level to generate an entry in the
       error log and allow a more orderly exit.
 
 2019-10-06 12:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     * Eval() calls replaced by _OOHG_Eval().
-     * Cell data is set before firing Click, RClick and DblClick events.
-     + Third parameter to function _GetGridCellData.
-     + Third parameter to function LISTVIEW_ITEMACTIVATE.
+  * core\source\h_grid.prg
+    * Eval() calls replaced by _OOHG_Eval().
+    * Cell data is set before firing Click, RClick and DblClick events.
+    + Third parameter to function _GetGridCellData.
+    + Third parameter to function LISTVIEW_ITEMACTIVATE.
 
 2019-10-06 12:09 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     * Eval() calls replaced by _OOHG_Eval().
-     * Cell data is set before firing Click, RClick, DblClick and
-       BeginDrag events.
+  * core\source\h_xbrowse.prg
+    * Eval() calls replaced by _OOHG_Eval().
+    * Cell data is set before firing Click, RClick, DblClick and
+      BeginDrag events.
 
 2019-10-06 12:07 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_browse.prg
-     * Eval() calls replaced by _OOHG_Eval().
+  * core\source\h_browse.prg
+    * Eval() calls replaced by _OOHG_Eval().
 
 2019-10-06 12:06 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_pseudofunc.ch
-     + hb_osIsWin10.
+  * core\include\i_pseudofunc.ch
+    + hb_osIsWin10.
 
 2019-10-06 12:05 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_lang.ch
-     + SET CODEPAGE command.
-     + Some languages.
-   ; Now OOHG supports the same features as HMG Extended.
+  * core\include\i_lang.ch
+    + SET CODEPAGE command.
+    + Some languages.
+    ; Now OOHG supports the same features as HMG Extended.
 
 2019-10-06 12:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
   * core\ChangeLog_006.txt
     * Comment.
 
 2019-09-26 18:27 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\oohg.h
-     + HB_STORVNLL define.
-   * core\source\c_winapimsc.c
-     ! BCC compiler error.
-     ! Functions SetLayeredWindowAttributes is using wrong variable.
-     ! Function MemoryStatus return values.
-   * core\source\c_winapimsc.c
-     ! BCC compiler error.
+  * core\source\oohg.h
+    + HB_STORVNLL define.
+  * core\source\c_winapimsc.c
+    ! BCC compiler error.
+    ! Functions SetLayeredWindowAttributes is using wrong variable.
+    ! Function MemoryStatus return values.
+  * core\source\c_winapimsc.c
+    ! BCC compiler error.
 
 2019-09-25 20:27 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     ! Method PrintImageX of class TPdfPrint does not work
-       properly when aSize parameter is .T. (imagesize) and
-       units are set to ROWCOL.
+  * core\source\h_print.prg
+    ! Method PrintImageX of class TPdfPrint does not work
+      properly when aSize parameter is .T. (imagesize) and
+      units are set to ROWCOL.
 
 2019-09-25 20:23 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     + Parameter lImageSize to method Print of class TWindow.
+  * core\source\h_windows.prg
+    + Parameter lImageSize to method Print of class TWindow.
 
 2019-09-25 17:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_gdiplus.c
-     ! Can't generate JPG image from handle.
+  * core\source\c_gdiplus.c
+    ! Can't generate JPG image from handle.
 
 2019-09-23 18:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     ! Ambiguous reference '_OOHG_GETLANGUAGE'.
+  * core\source\winprint.prg
+    ! Ambiguous reference '_OOHG_GETLANGUAGE'.
 
 2019-09-23 18:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     + Method InitMessages.
-     + Method SaveMetafiles moved to #ifndef NO_GUI section.
-     * Messages are now initilized at method New instead of
-       Preview so they can be used with NO_GUI.
-     * Method New now accepts a language code as parameter.
+  * core\source\winprint.prg
+    + Method InitMessages.
+    + Method SaveMetafiles moved to #ifndef NO_GUI section.
+    * Messages are now initilized at method New instead of
+      Preview so they can be used with NO_GUI.
+    * Method New now accepts a language code as parameter.
 
 2019-09-23 17:33 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\winprint.ch
-     + ifndef to avoid compiler error caused by duplicated defines.
+  * core\include\winprint.ch
+    + ifndef to avoid compiler error caused by duplicated defines.
 
 2019-09-22 22:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+    * Updated.
 
 2019-09-22 22:38 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     + Function _OOHG_GetLanguage to return last language set.
-     + Function InitMessages now sets the messages used by
-       h_error.prg
-   * core\source\h_error.prg
-     + Function _OOHG_SetErrorMsgs to allow the setting of the
-       messages used by the module.
-     ! Recursive error that happened when trying to access a
-       message from h_init.prg using function _OOHG_Messages.
+  * core\source\h_init.prg
+    + Function _OOHG_GetLanguage to return last language set.
+    + Function InitMessages now sets the messages used by
+      h_error.prg
+  * core\source\h_error.prg
+    + Function _OOHG_SetErrorMsgs to allow the setting of the
+      messages used by the module.
+    ! Recursive error that happened when trying to access a
+      message from h_init.prg using function _OOHG_Messages.
 
 2019-09-22 21:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     + DATA lReleased.
-   * core\source\h_form.prg
-     ! After closing a TGridControl's input window the focus is
-       not returned to its parent.
-     + METHOD ReleaseAttached.
-     * Method Events_Destroy moved to WM_DESTROY handler.
+  * core\source\h_windows.prg
+    + DATA lReleased.
+  * core\source\h_form.prg
+    ! After closing a TGridControl's input window the focus is
+      not returned to its parent.
+    + METHOD ReleaseAttached.
+    * Method Events_Destroy moved to WM_DESTROY handler.
 
 2019-09-18 19:21 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     ! Method PrintResource of class TPrintBase.
+  * core\source\h_print.prg
+    ! Method PrintResource of class TPrintBase.
 
 2019-09-18 18:49 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_image.c
-     + Parameter lColor to Function _OOHG_BitmapFromFile.
-       It allows to specify a color as the backcolor.
+  * core\source\c_image.c
+    + Parameter lColor to Function _OOHG_BitmapFromFile.
+      It allows to specify a color as the backcolor.
 
 2019-09-18 18:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     + Method PrintBitmapX of class TMINIPRINT.
+  * core\source\h_print.prg
+    + Method PrintBitmapX of class TMINIPRINT.
 
 2019-09-18 18:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-     ! Image from file printing is not working.
-     ! Image from hbitmap printing is not working.
+  * core\source\miniprint.prg
+    ! Image from file printing is not working.
+    ! Image from hbitmap printing is not working.
 
 2019-09-18 18:38 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     + DATA NotifyOnSave to class HBPrinter. Defaults to .F.
-       When .T. a "Done!" message will be displayed after
-       saving the page to a file.
-     % Messages definition.
-     * "EN" is now the default language.
+  * core\source\winprint.prg
+    + DATA NotifyOnSave to class HBPrinter. Defaults to .F.
+      When .T. a "Done!" message will be displayed after
+      saving the page to a file.
+    % Messages definition.
+    * "EN" is now the default language.
 
 2019-09-17 20:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg_dyns.hbx
-   * core\include\miniprint_dyns.hbx
-     * Updated.
+  * core\include\oohg_dyns.hbx
+  * core\include\miniprint_dyns.hbx
+    * Updated.
 
 2019-09-17 20:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     - MEMVAR _OOHG_PRINTER_DocName.
-     * The parameters of Method PrintBitMap of class TPrintBase
-       and Method PrintBitMapX of class THBPrinter were modified
-       to follow the recent changes at HBPrinter.
-       INCOMPATIBLE
-       ; If you need to apply one of the older options please use
-       one of the OOHG drawing functions (e.g. _OOHG_DrawBitMap).
-     + Parameter aExt to Method PrintImage of class TPrintBase and
-       Methods PrintImageX of classes TMiniPrint and THBPrinter.
-       It allows to specify an extension rectangle in which the
-       image will be replicated. Defaults to no extension.
-     * Method PrintImage of class TPrintBase, Method PrintImageX
-       of class TMiniPrint and Method PrintImageX of class
-       THBPrinter will print the image at its full size if aSize
-       parameter is set to .T.
-       Defaults to .F.
-     * Method PrintImageX of class TMiniPrint now uses
-       PRINT IMAGE IMAGESIZE command.
-     * Method PrintImageX of class THBPrinter now uses
-       PICTURE IMAGESIZE command.
-     + Parameter aExt to Methods PrintImageX of classes
-       TExcelPrint, TPdfPrint and TCalcPrint.
-       It does nothing.
-     % Method PrintImageX of class TExcelPrint.
-     * Method PrintImageX of class TPdfPrint will print the image
-       at its full size if aSize parameter is set to .T.
-       Defaults to .F.
-     * Method PrintImageX of class TCalcPrint will print the image
-       at its full size if aResol parameter is set to NIL and
-       aSize parameter is set to .T., if aSize is set to .F then
-       the image size will be determine by the comined height and
-       width of the printing rectangle.
-     * Some comments.
+  * core\source\h_print.prg
+    - MEMVAR _OOHG_PRINTER_DocName.
+    * The parameters of Method PrintBitMap of class TPrintBase
+      and Method PrintBitMapX of class THBPrinter were modified
+      to follow the recent changes at HBPrinter.
+      INCOMPATIBLE
+    ; If you need to apply one of the older options please use
+      one of the OOHG drawing functions (e.g. _OOHG_DrawBitMap).
+    + Parameter aExt to Method PrintImage of class TPrintBase and
+      Methods PrintImageX of classes TMiniPrint and THBPrinter.
+      It allows to specify an extension rectangle in which the
+      image will be replicated. Defaults to no extension.
+    * Method PrintImage of class TPrintBase, Method PrintImageX
+      of class TMiniPrint and Method PrintImageX of class
+      THBPrinter will print the image at its full size if aSize
+      parameter is set to .T.
+      Defaults to .F.
+    * Method PrintImageX of class TMiniPrint now uses
+      PRINT IMAGE IMAGESIZE command.
+    * Method PrintImageX of class THBPrinter now uses
+      PICTURE IMAGESIZE command.
+    + Parameter aExt to Methods PrintImageX of classes
+      TExcelPrint, TPdfPrint and TCalcPrint.
+      It does nothing.
+    % Method PrintImageX of class TExcelPrint.
+    * Method PrintImageX of class TPdfPrint will print the image
+      at its full size if aSize parameter is set to .T.
+      Defaults to .F.
+    * Method PrintImageX of class TCalcPrint will print the image
+      at its full size if aResol parameter is set to NIL and
+      aSize parameter is set to .T., if aSize is set to .F then
+      the image size will be determine by the comined height and
+      width of the printing rectangle.
+    * Some comments.
 
 2019-09-17 20:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.ch
-     * The BITMAP commands were modified to follow the class's
-       philosophy.
-       INCOMPATIBLE.
+  * core\source\winprint.ch
+    * The BITMAP commands were modified to follow the class's
+      philosophy.
+      INCOMPATIBLE.
 
-   * core\source\winprint.prg
-     * The parameters of Method Bitmap and Function RR_DrawBitmap
-       were modified to follow the class's philosophy.
-       INCOMPATIBLE.
-     - Function ArrayIsValidColor.
-     * Some comments.
-     ! Resource leak at function RR_DrawPicture.
+  * core\source\winprint.prg
+    * The parameters of Method Bitmap and Function RR_DrawBitmap
+      were modified to follow the class's philosophy.
+      INCOMPATIBLE.
+    - Function ArrayIsValidColor.
+    * Some comments.
+    ! Resource leak at function RR_DrawPicture.
 
 2019-09-17 20:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_pseudofunc.ch
-     - Pseudofunctions:
-          _HMG_PRINTER_GetPrintableAreaWidth,
-          _HMG_PRINTER_GetPrintableAreaHeight,
-          _HMG_PRINTER_GetPrintableAreaHorizontalOffset,
-          _HMG_PRINTER_GetPrintableAreaVerticalOffset,
-          _HMG_PRINTER_GetPrinter and
-          _HMG_PRINTER_aPrinters.
+  * core\include\i_pseudofunc.ch
+    - Pseudofunctions:
+         _HMG_PRINTER_GetPrintableAreaWidth,
+         _HMG_PRINTER_GetPrintableAreaHeight,
+         _HMG_PRINTER_GetPrintableAreaHorizontalOffset,
+         _HMG_PRINTER_GetPrintableAreaVerticalOffset,
+         _HMG_PRINTER_GetPrinter and
+         _HMG_PRINTER_aPrinters.
 
-   * core\include\miniprint.ch
-     + PRINT IMAGE IMAGESIZE command.
-     + PRINT BITMAP commands.
-     * _OOHG_PRINTER_DocName replaced by _HMG_PRINTER_GetJobName().
-     * Some format.
-     ! PRINT FILL command had wrong clauses.
-     - Duplicated PRINT RECTANGLE command.
-     ! PRINT ARC command had wrong clauses.
-     ! PRINT PIE command had wrong clauses.
+  * core\include\miniprint.ch
+    + PRINT IMAGE IMAGESIZE command.
+    + PRINT BITMAP commands.
+    * _OOHG_PRINTER_DocName replaced by _HMG_PRINTER_GetJobName().
+    * Some format.
+    ! PRINT FILL command had wrong clauses.
+    - Duplicated PRINT RECTANGLE command.
+    ! PRINT ARC command had wrong clauses.
+    ! PRINT PIE command had wrong clauses.
 
-   * core\source\miniprint.prg
-     * Some format and comments.
-     ! Function _HMG_PRINTER_H_Ellipse was calling the wrong
-       C-level function.
-     * Parameters nWidth and nHeigt of _HMG_PRINTER_C_IMAGE now
-       default to image's width and height when 0.
-     + Procedure _HMG_PRINTER_H_Bitmap to print a bitmap from
-       its handle.
-     * PROCEDURE _HMG_PRINTER_InitUserMessages now sets the
-       default job name.
-     + _HMG_PRINTER_UserMessages item to hold the error messages
-       thrown by _HMG_PRINTER_SetPrinterProperties().
-     * Function GetPrintableAreaWidth renamed as
-       _HMG_PRINTER_GetPrintableAreaWidth.
-     + Function GetPrintableAreaWidth. It calls
-       _HMG_PRINTER_GetPrintableAreaWidth. Note that is marked
-       as deprecated and it will be deleted at a future release.
-     * Function GetPrintableAreaHeight renamed as
-       _HMG_PRINTER_GetPrintableAreaHeight.
-     + Function GetPrintableAreaHeight. It calls
-       _HMG_PRINTER_GetPrintableAreaHeight. Note that is marked
-       as deprecated and it will be deleted at a future release.
-     * Function GetPrintableAreaHorizontalOffset renamed as
-       _HMG_PRINTER_GetPrintableAreaHorizontalOffset.
-     + Function GetPrintableAreaHorizontalOffset. It calls
-       _HMG_PRINTER_GetPrintableAreaHorizontalOffset. Note that is
-       marked as deprecated and it will be deleted at a future
-       release.
-     * Function GetPrintableAreaVerticalOffset renamed as
-       _HMG_PRINTER_GetPrintableAreaVerticalOffset. 
-     + Function GetPrintableAreaVerticalOffset. It calls
-       _HMG_PRINTER_GetPrintableAreaVerticalOffset. Note that is
-       marked as deprecated and it will be deleted at a future
-       release.
-     * Function GetPrinter renamed as _HMG_PRINTER_GetPrinter.
-     + Function GetPrinter. It calls _HMG_PRINTER_GetPrinter.
-       Note that is marked as deprecated and it will be deleted
-       at a future release.
-     * C-level function aPrinters renamed as
-       _HMG_PRINTER_C_aPrinters.
-     + Function aPrinters. It calls _HMG_PRINTER_aPrinters.
-       Note that is marked as deprecated and it will be deleted
-       at a future release.
-     + Function _HMG_PRINTER_aPrinters. It calls
-       _HMG_PRINTER_C_aPrinters.
-     + Function _HMG_PRINTER_GetJobName.
-       Returns _OOHG_PRINTER_DocName.
-     * Function _HMG_PRINTER_TextAlign now returns the previous
-       alignment.
-     + Function _HMG_PRINTER_SetPrinterProperties at PRG level.
-     + Static function _HMG_PRINTER_ErrMsg.
-     * Use hb_parclen() instead of strlen( hb_parc() ).
-     + Angle support at function _HMG_PRINTER_C_Multiline_Print.
-     * C-level function _HMG_PRINTER_SetPrinterProperties
-       renamed to _HMG_PRINTER_C_SetPrinterProperties.
-     ! Scale parameter setting is not working at function
-       _HMG_PRINTER_C_SetPrinterProperties.
-     * _HMG_PRINTER_C_SetPrinterProperties now returns all the
-       printer's properties.
-     + Additional image types to function _HMG_PRINTER_C_Image.
-     * Function _HMG_PRINTER_C_Image now return .T./.F. on
-       success/failure.
-     + Function _HMG_PRINTER_C_Bitmap.
+  * core\source\miniprint.prg
+    * Some format and comments.
+    ! Function _HMG_PRINTER_H_Ellipse was calling the wrong
+      C-level function.
+    * Parameters nWidth and nHeigt of _HMG_PRINTER_C_IMAGE now
+      default to image's width and height when 0.
+    + Procedure _HMG_PRINTER_H_Bitmap to print a bitmap from
+      its handle.
+    * PROCEDURE _HMG_PRINTER_InitUserMessages now sets the
+      default job name.
+    + _HMG_PRINTER_UserMessages item to hold the error messages
+      thrown by _HMG_PRINTER_SetPrinterProperties().
+    * Function GetPrintableAreaWidth renamed as
+      _HMG_PRINTER_GetPrintableAreaWidth.
+    + Function GetPrintableAreaWidth. It calls
+      _HMG_PRINTER_GetPrintableAreaWidth. Note that is marked
+      as deprecated and it will be deleted at a future release.
+    * Function GetPrintableAreaHeight renamed as
+      _HMG_PRINTER_GetPrintableAreaHeight.
+    + Function GetPrintableAreaHeight. It calls
+      _HMG_PRINTER_GetPrintableAreaHeight. Note that is marked
+      as deprecated and it will be deleted at a future release.
+    * Function GetPrintableAreaHorizontalOffset renamed as
+      _HMG_PRINTER_GetPrintableAreaHorizontalOffset.
+    + Function GetPrintableAreaHorizontalOffset. It calls
+      _HMG_PRINTER_GetPrintableAreaHorizontalOffset. Note that is
+      marked as deprecated and it will be deleted at a future
+      release.
+    * Function GetPrintableAreaVerticalOffset renamed as
+      _HMG_PRINTER_GetPrintableAreaVerticalOffset.
+    + Function GetPrintableAreaVerticalOffset. It calls
+      _HMG_PRINTER_GetPrintableAreaVerticalOffset. Note that is
+      marked as deprecated and it will be deleted at a future
+      release.
+    * Function GetPrinter renamed as _HMG_PRINTER_GetPrinter.
+    + Function GetPrinter. It calls _HMG_PRINTER_GetPrinter.
+      Note that is marked as deprecated and it will be deleted
+      at a future release.
+    * C-level function aPrinters renamed as
+      _HMG_PRINTER_C_aPrinters.
+    + Function aPrinters. It calls _HMG_PRINTER_aPrinters.
+      Note that is marked as deprecated and it will be deleted
+      at a future release.
+    + Function _HMG_PRINTER_aPrinters. It calls
+      _HMG_PRINTER_C_aPrinters.
+    + Function _HMG_PRINTER_GetJobName.
+      Returns _OOHG_PRINTER_DocName.
+    * Function _HMG_PRINTER_TextAlign now returns the previous
+      alignment.
+    + Function _HMG_PRINTER_SetPrinterProperties at PRG level.
+    + Static function _HMG_PRINTER_ErrMsg.
+    * Use hb_parclen() instead of strlen( hb_parc() ).
+    + Angle support at function _HMG_PRINTER_C_Multiline_Print.
+    * C-level function _HMG_PRINTER_SetPrinterProperties
+      renamed to _HMG_PRINTER_C_SetPrinterProperties.
+    ! Scale parameter setting is not working at function
+      _HMG_PRINTER_C_SetPrinterProperties.
+    * _HMG_PRINTER_C_SetPrinterProperties now returns all the
+      printer's properties.
+    + Additional image types to function _HMG_PRINTER_C_Image.
+    * Function _HMG_PRINTER_C_Image now return .T./.F. on
+      success/failure.
+    + Function _HMG_PRINTER_C_Bitmap.
 
 2019-09-17 16:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     * Comment.
+  * core\source\h_form.prg
+    * Comment.
 
 2019-09-17 16:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_image.c
-     % Module handle usage.
+  * core\source\c_image.c
+    % Module handle usage.
 
 2019-09-13 23:39 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     * Some format.
-     ! RTE (access violation) at function InvertRect.
-     * Now only constructor method returns Self, others that
-       previously return Self now return NIL. INCOMPATIBLE
-     * Function RR_DrawPicture now returns .T./.F. upon
-       success/failure.
-     ! Resource leak at function RR_GetPixelColor.
+  * core\source\winprint.prg
+    * Some format.
+    ! RTE (access violation) at function InvertRect.
+    * Now only constructor method returns Self, others that
+      previously return Self now return NIL. INCOMPATIBLE
+    * Function RR_DrawPicture now returns .T./.F. upon
+      success/failure.
+    ! Resource leak at function RR_GetPixelColor.
 
 2019-09-13 18:43 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     * Some format and comments.
-     * Table parameter of function _OOHG_Messages replaced by
-       its corresponding define for readability.
-     * Some function calls were replaced by the corresponding
-       pseudofunctions for readability.
-     + Support for IMAGESIZE to THBPrinter:PrintImageX.
+  * core\source\h_print.prg
+    * Some format and comments.
+    * Table parameter of function _OOHG_Messages replaced by
+      its corresponding define for readability.
+    * Some function calls were replaced by the corresponding
+      pseudofunctions for readability.
+    + Support for IMAGESIZE to THBPrinter:PrintImageX.
 
 2019-09-13 17:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     + Function GetTaskBarHeight.
+  * core\source\c_winapimisc.c
+    + Function GetTaskBarHeight.
 
 2019-09-13 17:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\winprint.ch
-     ! Missing ALTERNATE and WINDING defines.
-     ! Wrong constant at DRAW IMAGELIST command.
+  * core\include\winprint.ch
+    ! Missing ALTERNATE and WINDING defines.
+    ! Wrong constant at DRAW IMAGELIST command.
 
 2019-09-12 19:27 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_internal.prg
-     ! ON CLICK event is not working.
-     ! TAB freezes app if internal has no controls.
-     * Some format.
+  * core\source\h_internal.prg
+    ! ON CLICK event is not working.
+    ! TAB freezes app if internal has no controls.
+    * Some format.
 
 2019-09-10 20:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_report.prg
-     ! Missing READONLY property at DATA Type.
+  * core\source\h_report.prg
+    ! Missing READONLY property at DATA Type.
 
 2019-09-10 18:43 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_xbrowse.prg
-     * Includes reordered.
-     * Table parameter of function _OOHG_Messages replaced by
-       its corresponding define for readability.
-     ! ::Picture is inserted twice when a column is added.
+  * core\source\h_xbrowse.prg
+    * Includes reordered.
+    * Table parameter of function _OOHG_Messages replaced by
+      its corresponding define for readability.
+    ! ::Picture is inserted twice when a column is added.
 
 2019-09-10 18:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_application.prg
-     * Includes reordered.
-     * Table parameter of function _OOHG_Messages replaced by
-       its corresponding define for readability.
-     ! RTE on release.
+  * core\source\h_application.prg
+    * Includes reordered.
+    * Table parameter of function _OOHG_Messages replaced by
+      its corresponding define for readability.
+    ! RTE on release.
 
 2019-09-10 18:38 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_internal.prg
-   * core\source\h_msgbox.prg
-     * Includes reordered.
+  * core\source\h_internal.prg
+  * core\source\h_msgbox.prg
+    * Includes reordered.
 
 2019-09-10 18:36 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_windows.prg
-     * Table parameter of function _OOHG_Messages replaced by
-       its corresponding define for readability.
+  * core\source\h_windows.prg
+    * Table parameter of function _OOHG_Messages replaced by
+      its corresponding define for readability.
 
 2019-09-10 18:35 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_browse.prg
-   * core\source\h_controlmisc.prg
-   * core\source\h_crypt.prg
-   * core\source\h_edit.prg
-   * core\source\h_edit_ex.prg
-   * core\source\h_error.prg
-   * core\source\h_graph.prg
-   * core\source\h_grid.prg
-   * core\source\h_help.prg
-   * core\source\h_ini.prg
-   * core\source\h_menu.prg
-   * core\source\h_registry.prg
-   * core\source\h_report.prg
-   * core\source\h_scrsaver.prg
-     * Table parameter of function _OOHG_Messages replaced by
-       its corresponding define for readability.
+  * core\source\h_browse.prg
+  * core\source\h_controlmisc.prg
+  * core\source\h_crypt.prg
+  * core\source\h_edit.prg
+  * core\source\h_edit_ex.prg
+  * core\source\h_error.prg
+  * core\source\h_graph.prg
+  * core\source\h_grid.prg
+  * core\source\h_help.prg
+  * core\source\h_ini.prg
+  * core\source\h_menu.prg
+  * core\source\h_registry.prg
+  * core\source\h_report.prg
+  * core\source\h_scrsaver.prg
+    * Table parameter of function _OOHG_Messages replaced by
+      its corresponding define for readability.
 
 2019-09-10 18:29 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     * Some messages.
-     * Table parameter of function _OOHG_Messages replaced by
-       its corresponding define for readability.
+  * core\source\h_init.prg
+    * Some messages.
+    * Table parameter of function _OOHG_Messages replaced by
+      its corresponding define for readability.
 
 2019-09-10 16:43 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     - Forgotten debug call.
-     * Table parameter of function _OOHG_Messages replaced by
-       its corresponding define for readability.
+  * core\source\h_form.prg
+    - Forgotten debug call.
+    * Table parameter of function _OOHG_Messages replaced by
+      its corresponding define for readability.
 
 2019-09-10 16:40 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
    + core\include\h_init.ch
-     ; Contains defines to use with function _OOHG_Messages.
+    ; Contains defines to use with function _OOHG_Messages.
 
 2019-09-09 22:35 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_hb_compat.ch
-     + AScan with 5 parameters.
-   * core\include\i_pseudofunc.ch
-     + SetInteractiveClose.
-   * core\include\i_var.ch
-     + _OOHG_InteractiveClose and _OOHG_KeepAppOnMainRelease.
-   * core\include\i_window.ch
-     + INTERACTIVECLOSE [ ON | OFF | QUERY ] clause.
-   * core\source\h_application.prg
-     + Support for global vars _OOHG_InteractiveClose and
-       _OOHG_KeepAppOnMainRelease.
-     * _OOHG_Main can now be set to NIL if MAIN is released
-       and _OOHG_KeepAppOnMainRelease is .T.
-   * core\source\h_form.prg
-     - Static var _OOHG_InteractiveClose.
-     - Function SetInteractiveClose.
-     + DATA InteractiveClose to TForm CLASS.
-       Use it to establish a specific value on per form basis.
-       On form's close this data will be checked first, if
-       it's value is -1 (default value) then the global
-       value of _OOHG_InteractiveClose will be used.
-     - WM_DESTROY handler.
-     * The destruction of the windows is now done by the
-       default Windows procedure.
-     ! Method Release was wrongly checking interactive close
-       which prevented the programmatic release of the form.
-     ! DEFINE WINDOW registration failed error.
+  * core\include\i_hb_compat.ch
+    + AScan with 5 parameters.
+  * core\include\i_pseudofunc.ch
+    + SetInteractiveClose.
+  * core\include\i_var.ch
+    + _OOHG_InteractiveClose and _OOHG_KeepAppOnMainRelease.
+  * core\include\i_window.ch
+    + INTERACTIVECLOSE [ ON | OFF | QUERY ] clause.
+  * core\source\h_application.prg
+    + Support for global vars _OOHG_InteractiveClose and
+      _OOHG_KeepAppOnMainRelease.
+    * _OOHG_Main can now be set to NIL if MAIN is released
+      and _OOHG_KeepAppOnMainRelease is .T.
+  * core\source\h_form.prg
+    - Static var _OOHG_InteractiveClose.
+    - Function SetInteractiveClose.
+    + DATA InteractiveClose to TForm CLASS.
+      Use it to establish a specific value on per form basis.
+      On form's close this data will be checked first, if
+      it's value is -1 (default value) then the global
+      value of _OOHG_InteractiveClose will be used.
+    - WM_DESTROY handler.
+    * The destruction of the windows is now done by the
+      default Windows procedure.
+    ! Method Release was wrongly checking interactive close
+      which prevented the programmatic release of the form.
+    ! DEFINE WINDOW registration failed error.
 
 2019-09-08 22:20 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_form.prg
-     + ToolTip release at METHOD Events_Destroy.
-     + Set form's hWnd to NIL after window destruction.
-     * Some format.
+  * core\source\h_form.prg
+    + ToolTip release at METHOD Events_Destroy.
+    + Set form's hWnd to NIL after window destruction.
+    * Some format.
 
 2019-09-08 22:10 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_textbox.ch
-     + TOOLTIP sub-clause to ACTION and ACTION2 clauses.
-   * core\include\i_windefs.ch
-     + Defines for EM_SETPASSWORDCHAR and EM_GETPASSWORDCHAR.
-   * core\source\h_textbox.prg
-     * Some format.
-     + DATA aBitmap to hold buttons bitmaps.
-     + DATA bAction1 to hold button1 action.
-     + DATA bAction2 to hold button2 action.
-     + DATA cToolTipBut1 to hold button1 tooltip.
-     + DATA cToolTipBut2 to hold button2 tooltip.
-     + DATA nBtnWidth to hold button's width.
-     + DATA lRecreateOnReset. For textbox with PASSWORD
-       clause, .T. forces control recreation to reset
-       password CHAR to windows default. .F. means use
-       an '*' as password CHAR instead.
-     + METHOD Release.
-     + METHOD ReleaseAction.
-     + METHOD ReleaseAction2.
-     + METHOD DefineAction.
-     + METHOD DefineAction2.
-     + METHOD RedefinePasswordStyle.
-     + METHOD PasswordChar.
+  * core\include\i_textbox.ch
+    + TOOLTIP sub-clause to ACTION and ACTION2 clauses.
+  * core\include\i_windefs.ch
+    + Defines for EM_SETPASSWORDCHAR and EM_GETPASSWORDCHAR.
+  * core\source\h_textbox.prg
+    * Some format.
+    + DATA aBitmap to hold buttons bitmaps.
+    + DATA bAction1 to hold button1 action.
+    + DATA bAction2 to hold button2 action.
+    + DATA cToolTipBut1 to hold button1 tooltip.
+    + DATA cToolTipBut2 to hold button2 tooltip.
+    + DATA nBtnWidth to hold button's width.
+    + DATA lRecreateOnReset. For textbox with PASSWORD
+      clause, .T. forces control recreation to reset
+      password CHAR to windows default. .F. means use
+      an '*' as password CHAR instead.
+    + METHOD Release.
+    + METHOD ReleaseAction.
+    + METHOD ReleaseAction2.
+    + METHOD DefineAction.
+    + METHOD DefineAction2.
+    + METHOD RedefinePasswordStyle.
+    + METHOD PasswordChar.
 
 2019-09-08 21:01 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_menu.prg
-     + METHOD Enabled to TMenu CLASS.
-     * Use stock brushes to reduce resource usage.
+  * core\source\h_menu.prg
+    + METHOD Enabled to TMenu CLASS.
+    * Use stock brushes to reduce resource usage.
 
 2019-09-08 20:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_toolbar.prg
-     * The lib no longer generates an RTE when the user clicks a
-       DROPDOWN button that has no menu defined.
+  * core\source\h_toolbar.prg
+    * The lib no longer generates an RTE when the user clicks a
+      DROPDOWN button that has no menu defined.
 
 2019-09-08 20:52 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostarus.prg
-     ! Wrong function names and declarations.
-     - Duplicated code.
-   * core\source\c_gdiplus.c
-     ! Missing wrapper functions.
+  * core\source\bostarus.prg
+    ! Wrong function names and declarations.
+    - Duplicated code.
+  * core\source\c_gdiplus.c
+    ! Missing wrapper functions.
 
 2019-09-08 20:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_init.prg
-     * Comments.
-     + Functions InitMessages and _OOHG_Messages are now
-       thread safe.
+  * core\source\h_init.prg
+    * Comments.
+    + Functions InitMessages and _OOHG_Messages are now
+      thread safe.
 
 2019-09-08 20:42 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     + Functions GetGDIObjects, GetUserObjects and GetKernelObjects.
+  * core\source\c_winapimisc.c
+    + Functions GetGDIObjects, GetUserObjects and GetKernelObjects.
 
 2019-09-08 20:41 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_combo.prg
-     ! Missing call to ::SethWnd at TEditCombo CLASS.
+  * core\source\h_combo.prg
+    ! Missing call to ::SethWnd at TEditCombo CLASS.
 
 2019-09-08 20:39 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_image.c
-     ! Resource leaks at C functions _OOHG_OleLoadPicture,
-       _OOHG_ScaleImage, _OOHG_RotateImage and _OOHG_LoadImage.
-     + Check for empty filename at function _OOHG_SIZEOFBITMAPFROMFILE.
-     * Function _OOHG_SCALEIMAGE can now operate on a standalone hImage.
-     ! Resource leak at function _OOHG_BLENDIMAGE.
-     * Some format.
+  * core\source\c_image.c
+    ! Resource leaks at C functions _OOHG_OleLoadPicture,
+      _OOHG_ScaleImage, _OOHG_RotateImage and _OOHG_LoadImage.
+    + Check for empty filename at function _OOHG_SIZEOFBITMAPFROMFILE.
+    * Function _OOHG_SCALEIMAGE can now operate on a standalone hImage.
+    ! Resource leak at function _OOHG_BLENDIMAGE.
+    * Some format.
 
 2019-09-08 20:20 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_application.prg
-     + Code to unregister TInternal, TPicture and TTextArray
-       window classes.
-   * core\source\h_internal.prg
-     + Function _OOHG_TINTERNAL_UNREGISTER.
-   * core\source\h_picture.prg
-     + Function _OOHG_TPICTURE_UNREGISTER.
-     * Use stock brush to reduce resource usage.
-   * core\source\h_textarray.prg
-     + Function _OOHG_TTEXTARRAY_UNREGISTER.
+  * core\source\h_application.prg
+    + Code to unregister TInternal, TPicture and TTextArray
+      window classes.
+  * core\source\h_internal.prg
+    + Function _OOHG_TINTERNAL_UNREGISTER.
+  * core\source\h_picture.prg
+    + Function _OOHG_TPICTURE_UNREGISTER.
+    * Use stock brush to reduce resource usage.
+  * core\source\h_textarray.prg
+    + Function _OOHG_TTEXTARRAY_UNREGISTER.
 
 2019-09-08 20:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_timer.ch
-     + ONCE clause.
+  * core\include\i_timer.ch
+    + ONCE clause.
 
-   * core\include\oohg.h
-     + Define of s_Events_TimeOut.
-     + Member OriginalBrush to OOHG_Window structure.
-     + Declarations for some functions.
+  * core\include\oohg.h
+    + Define of s_Events_TimeOut.
+    + Member OriginalBrush to OOHG_Window structure.
+    + Declarations for some functions.
 
-   * core\source\c_controlmisc.c
-     + Events_TimeOut to s_SymbolNames array.
+  * core\source\c_controlmisc.c
+    + Events_TimeOut to s_SymbolNames array.
 
-   * core\source\h_controlmisc.prg
-     ! Resource leak at METHOD Release of TControl CLASS
-       caused by the release of the control before the
-       execution of METHOD Release of TWindow CLASS.
-     ! Resource leak at METHOD SetFont of TControl CLASS.
-     ! Resource leak at METHOD ClearBitmaps of TControl CLASS.
-     ! Resource leak at METHOD Events_Color of TControl CLASS.
-     + METHOD PosAddToCtrlsArrays to TControl CLASS.
+  * core\source\h_controlmisc.prg
+    ! Resource leak at METHOD Release of TControl CLASS
+      caused by the release of the control before the
+      execution of METHOD Release of TWindow CLASS.
+    ! Resource leak at METHOD SetFont of TControl CLASS.
+    ! Resource leak at METHOD ClearBitmaps of TControl CLASS.
+    ! Resource leak at METHOD Events_Color of TControl CLASS.
+    + METHOD PosAddToCtrlsArrays to TControl CLASS.
 
-   * core\source\h_timer.prg
-     * Some format.
-     + DATA lOnce. Defaults to .F.
-     + METHOD Events_TimeOut to executed the associated action.
+  * core\source\h_timer.prg
+    * Some format.
+    + DATA lOnce. Defaults to .F.
+    + METHOD Events_TimeOut to executed the associated action.
 
-   * core\source\h_windows.prg
-     + METHOD Events_Timeout to CLASS TWindow.
-     ! RTE at function ExitProcess when Application object
-       is not defined.
-     ! Resouce leak at METHOD Release of TWindow CLASS.
-     * METHOD Release of TWindow CLASS no longer sets
-       ::hWnd to NIL.
-       ; For forms it's done by WM_CLOSE handler.
-       ; For controls it's done by METHOD Release of
-         TControl CLASS.
-     * WM_CTLCOLORSTATIC and WM_CTLCOLORLISTBOX handlers
-       at METHOD Events of TWindow CLASS now send a color
-       constant to METHOD Events_Color instead of sending
-       a COLORREF.
-     * WM_TIMER handler now calls METHOD Events_TimeOut
-       instead of executing OnClick event.
+  * core\source\h_windows.prg
+    + METHOD Events_Timeout to CLASS TWindow.
+    ! RTE at function ExitProcess when Application object
+      is not defined.
+    ! Resouce leak at METHOD Release of TWindow CLASS.
+    * METHOD Release of TWindow CLASS no longer sets
+      ::hWnd to NIL.
+    ; For forms it's done by WM_CLOSE handler.
+    ; For controls it's done by METHOD Release of
+        TControl CLASS.
+    * WM_CTLCOLORSTATIC and WM_CTLCOLORLISTBOX handlers
+      at METHOD Events of TWindow CLASS now send a color
+      constant to METHOD Events_Color instead of sending
+      a COLORREF.
+    * WM_TIMER handler now calls METHOD Events_TimeOut
+      instead of executing OnClick event.
 
 2019-09-08 20:06 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_scroll.prg
-     * Comment.
+  * core\source\h_scroll.prg
+    * Comment.
 
 2019-09-08 18:47 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_button.ch
-     + NODESTROY clause.
-       It prevents the destruction of the hbitmap at release.
-   * core\source\h_button.prg
-     + DATA lNoDestroy. Defaults to .F.
-     ! Missing parameters at method DefineImage.
-     ! Resource leak.
+  * core\include\i_button.ch
+    + NODESTROY clause.
+      It prevents the destruction of the hbitmap at release.
+  * core\source\h_button.prg
+    + DATA lNoDestroy. Defaults to .F.
+    ! Missing parameters at method DefineImage.
+    ! Resource leak.
 
 2019-08-30 19:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_var.prg
-     + _OOHG_EnableClassUnreg and _OOHG_ExitOnMainRelease.
-     ; Both default to .T.
-   * core\source\h_application.prg
-     + Logic to handle the registration and unregistration of
-       window classes.
-     + Support for _OOHG_EnableClassUnreg and
-       _OOHG_ExitOnMainRelease.
-     ! Initial values of ThisControl var.
-     * Use _OOHG_DeleteArrayItem instead of ADel + ASize.
-     + Cleanup code to method Release that releases stacks,
-       mutexes, objects and arrays.
-   * core\source\h_form.prg
-     * Some format and comments.
-     % Reduced the amount of memory used by a program which
-       creates a great number of nameless windows.
-     ; Note that the old behaviour was not leaking memory but
-       delaying its release until app's end.
-     ; To restore previous behaviour set _OOHG_EnableClassUnreg
-       var to .F.
-     ! Method BackColor was not resetting the window class brush.
-     * Event codeblocks are set to NIL at method Events_Destroy
-       to avoid problems with detached references.
-     + Method Events_Destroy is now called by _ReleaseWindowList
-       function to release all attached controls and data.
-     * Function RegisterWindow now returns the bitmap asociated
-       with the class icon to allow releasing it at class unreg.
+  * core\include\i_var.prg
+    + _OOHG_EnableClassUnreg and _OOHG_ExitOnMainRelease.
+    ; Both default to .T.
+  * core\source\h_application.prg
+    + Logic to handle the registration and unregistration of
+      window classes.
+    + Support for _OOHG_EnableClassUnreg and
+      _OOHG_ExitOnMainRelease.
+    ! Initial values of ThisControl var.
+    * Use _OOHG_DeleteArrayItem instead of ADel + ASize.
+    + Cleanup code to method Release that releases stacks,
+      mutexes, objects and arrays.
+  * core\source\h_form.prg
+    * Some format and comments.
+    % Reduced the amount of memory used by a program which
+      creates a great number of nameless windows.
+    ; Note that the old behaviour was not leaking memory but
+      delaying its release until app's end.
+    ; To restore previous behaviour set _OOHG_EnableClassUnreg
+      var to .F.
+    ! Method BackColor was not resetting the window class brush.
+    * Event codeblocks are set to NIL at method Events_Destroy
+      to avoid problems with detached references.
+    + Method Events_Destroy is now called by _ReleaseWindowList
+      function to release all attached controls and data.
+    * Function RegisterWindow now returns the bitmap asociated
+      with the class icon to allow releasing it at class unreg.
 
 2019-08-30 18:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_menu.prg
-     + Some cleanup code to release attached objects.
+  * core\source\h_menu.prg
+    + Some cleanup code to release attached objects.
 
 2019-08-30 18:27 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_richeditbox.prg
-     + Function _RichEdit_DeInit. Now RICHED20.DLL is loaded once.
-     * Format.
+  * core\source\h_richeditbox.prg
+    + Function _RichEdit_DeInit. Now RICHED20.DLL is loaded once.
+    * Format.
 
 2019-08-30 17:58 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     + Functions _ComCtl32_DeInit, GetComCtl32Version, IsAppThemed
-       and IsXPThemeActive moved from h_windows.prg.
-     + Wrapper functions for theme related functions.
-   * core\source\h_button.prg
-   * core\source\h_checkbox.prg
-   * core\source\h_controlmisc.prg
-   * core\source\h_radio.prg
-   * core\source\h_tooltip.prg
-     * Use wrapper functions to call theme related functions.
-   * core\source\h_windows.prg
-     + Method IconHandle to CLASS TWindow.
-     + Method ReleaseAttached of CLASS TWindow now sets to NIL the
-       codeblocks associated to hot keys, accelerator commands and
-       scrollbars.
-     * _OOHG_NestedSameEvent and _OOHG_GlobalRTL are now declared
-       as BOOL.
-     * _OOHG_NestedSameEvent is now thread safe.
-     ! Resource leak at method Release of CLASS TWindows.
-     * Use wrapper functions to call theme related functions.
-     - Functions _ComCtl32_DeInit, GetComCtl32Version, IsAppThemed
-       and IsXPThemeActive moved to c_winapimisc.c.
+  * core\source\c_winapimisc.c
+    + Functions _ComCtl32_DeInit, GetComCtl32Version, IsAppThemed
+      and IsXPThemeActive moved from h_windows.prg.
+    + Wrapper functions for theme related functions.
+  * core\source\h_button.prg
+  * core\source\h_checkbox.prg
+  * core\source\h_controlmisc.prg
+  * core\source\h_radio.prg
+  * core\source\h_tooltip.prg
+    * Use wrapper functions to call theme related functions.
+  * core\source\h_windows.prg
+    + Method IconHandle to CLASS TWindow.
+    + Method ReleaseAttached of CLASS TWindow now sets to NIL the
+      codeblocks associated to hot keys, accelerator commands and
+      scrollbars.
+    * _OOHG_NestedSameEvent and _OOHG_GlobalRTL are now declared
+      as BOOL.
+    * _OOHG_NestedSameEvent is now thread safe.
+    ! Resource leak at method Release of CLASS TWindows.
+    * Use wrapper functions to call theme related functions.
+    - Functions _ComCtl32_DeInit, GetComCtl32Version, IsAppThemed
+      and IsXPThemeActive moved to c_winapimisc.c.
 
 2019-08-30 17:24 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.h
-     + Declarations for some functions.
+  * core\include\oohg.h
+    + Declarations for some functions.
 
 2019-08-29 16:14 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_winapimisc.c
-     - No longer needed function declarations.
+  * core\source\c_winapimisc.c
+    - No longer needed function declarations.
 
 2019-08-29 16:12 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.h
-     + Declarations for some functions.
-     + IconHandle member to OCTRL structure.
+  * core\include\oohg.h
+    + Declarations for some functions.
+    + IconHandle member to OCTRL structure.
 
 2019-08-29 16:08 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     ! Wrong parameters prevent library building.
+  * core\source\bostaurus.prg
+    ! Wrong parameters prevent library building.
 
 2019-08-28 20:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\bostaurus.ch
-     + BT_DIRECTORYINFO as pseudofunction.
-   * core\source\bostaurus.prg
-     - Comments.
-     + Function bt_Bitmap_To_Stream (previously commented out).
-     + Function bt_GetEncoderCLSID (previously commented out).
-     + Function bt_SaveGDIPlusPicture (previously commented out).
-     * Function bt_SpaceToBlank now calls _SpaceToBlank.
-     * Function bt_LocalDateTimeToDateTimeANSI now calls
-       _LocalDateTimeToDateTimeANSI.
-     - Function win_StrRetToBuf (moved to c_winapimisc.c).
-     * Functions that need GDI+ support now use c_gdiplus.c
-   * core\source\c_activex.c
-     + Function _Ax_DeInit. Now atl.dll is loaded once.
-   * core\source\c_gdiplus.c
-     * Comments and format.
-     * Uncrustified using Harbour specs.
-     * Static vars are now thread safe.
-     - Uneeded code from function SaveHBitmapToFile that was
-       leaking memory.
-   * core\source\c_image.c
-     * Static var _OOHG_StretchBltMode is now thread safe.
-     ! GDI object leak at function _OOHG_LoadImage.
-     * Use hb_parclen() instead of strlen( hb_parc() ).
-     - Unneeded code.
-   * core\source\c_msgbox.c
-     - Function MessageBoxTimeout (moved to c_winapimisc.c).
-   * core\source\c_winapimisc.c
-     * Comments.
-     * Function MemoryStatus now returns an array when no valid
-       numeric parameter is specified. Useful  to chase leaks.
-     + Function _ShlWAPI_DeInit. Now shlwapi.dll is loaded once.
-     + Function _ProcessLib_DeInit. Now psapi.dll is loaded once.
-     + Function _User32_DeInit. Now user32.dll is loaded once.
-     + Functions _SpaceToBlank, _LocalDateTimeToDateTimeANSI,
-       win_StrRetToBuf and DirectoryInfo (from bostaurus.prg).
-     + Function GetObjectCount. It returns an array with the
-       current number of opened GDI, user and kernel objects.
-     + Function EmptyWorkingSet.
-     + Function MessageBoxTimeout (from c_msgbox.c).
-     + Function SetLayeredWindowAttributes (from c_windows.c).
-     + Function FreeLibraries to unload libs loaded by OOHG.
-   * core\source\c_windows.c
-     - Function SetLayeredWindowAttributes (moved to c_winapimisc.c).
-     * Function DestroyWindow now return .T./.F. on success/fail.
-     + Comments.
-     ! Function SetWindowBackColor now will call method BackColor
-       if the window's hWnd belongs to a TForm object.
-     + Function GetWindowBackColor.
-     + Function _DWMAPI_DeInit. Now dwmapi.dll is loaded once.
-     - Function SetLayeredWindowAttributes (moved to c_winapimisc.c).
+  * core\include\bostaurus.ch
+    + BT_DIRECTORYINFO as pseudofunction.
+  * core\source\bostaurus.prg
+    - Comments.
+    + Function bt_Bitmap_To_Stream (previously commented out).
+    + Function bt_GetEncoderCLSID (previously commented out).
+    + Function bt_SaveGDIPlusPicture (previously commented out).
+    * Function bt_SpaceToBlank now calls _SpaceToBlank.
+    * Function bt_LocalDateTimeToDateTimeANSI now calls
+      _LocalDateTimeToDateTimeANSI.
+    - Function win_StrRetToBuf (moved to c_winapimisc.c).
+    * Functions that need GDI+ support now use c_gdiplus.c
+  * core\source\c_activex.c
+    + Function _Ax_DeInit. Now atl.dll is loaded once.
+  * core\source\c_gdiplus.c
+    * Comments and format.
+    * Uncrustified using Harbour specs.
+    * Static vars are now thread safe.
+    - Uneeded code from function SaveHBitmapToFile that was
+      leaking memory.
+  * core\source\c_image.c
+    * Static var _OOHG_StretchBltMode is now thread safe.
+    ! GDI object leak at function _OOHG_LoadImage.
+    * Use hb_parclen() instead of strlen( hb_parc() ).
+    - Unneeded code.
+  * core\source\c_msgbox.c
+    - Function MessageBoxTimeout (moved to c_winapimisc.c).
+  * core\source\c_winapimisc.c
+    * Comments.
+    * Function MemoryStatus now returns an array when no valid
+      numeric parameter is specified. Useful  to chase leaks.
+    + Function _ShlWAPI_DeInit. Now shlwapi.dll is loaded once.
+    + Function _ProcessLib_DeInit. Now psapi.dll is loaded once.
+    + Function _User32_DeInit. Now user32.dll is loaded once.
+    + Functions _SpaceToBlank, _LocalDateTimeToDateTimeANSI,
+      win_StrRetToBuf and DirectoryInfo (from bostaurus.prg).
+    + Function GetObjectCount. It returns an array with the
+      current number of opened GDI, user and kernel objects.
+    + Function EmptyWorkingSet.
+    + Function MessageBoxTimeout (from c_msgbox.c).
+    + Function SetLayeredWindowAttributes (from c_windows.c).
+    + Function FreeLibraries to unload libs loaded by OOHG.
+  * core\source\c_windows.c
+    - Function SetLayeredWindowAttributes (moved to c_winapimisc.c).
+    * Function DestroyWindow now return .T./.F. on success/fail.
+    + Comments.
+    ! Function SetWindowBackColor now will call method BackColor
+      if the window's hWnd belongs to a TForm object.
+    + Function GetWindowBackColor.
+    + Function _DWMAPI_DeInit. Now dwmapi.dll is loaded once.
+    - Function SetLayeredWindowAttributes (moved to c_winapimisc.c).
 
 2019-08-28 18:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_pseudofunc.ch
-     ! Typo.
+  * core\include\i_pseudofunc.ch
+    ! Typo.
 
 2019-08-28 17:38 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_pseudofunc.ch
-     ! Typo.
-     + Pseudofunctions:
-          _HMG_PRINTER_GetPrintableAreaWidth,
-          _HMG_PRINTER_GetPrintableAreaHeight,
-          _HMG_PRINTER_GetPrintableAreaHorizontalOffset,
-          _HMG_PRINTER_GetPrintableAreaVerticalOffset,
-          _HMG_PRINTER_GetPrinter and
-          _HMG_PRINTER_aPrinters.
+  * core\include\i_pseudofunc.ch
+    ! Typo.
+    + Pseudofunctions:
+      _HMG_PRINTER_GetPrintableAreaWidth,
+      _HMG_PRINTER_GetPrintableAreaHeight,
+      _HMG_PRINTER_GetPrintableAreaHorizontalOffset,
+      _HMG_PRINTER_GetPrintableAreaVerticalOffset,
+      _HMG_PRINTER_GetPrinter and
+      _HMG_PRINTER_aPrinters.
 
 2019-08-28 17:18 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_hmg_compat.ch
-     + Pseudofunctions _SetWindowBackColor and GlobalMemoryStatusEx.
+  * core\include\i_hmg_compat.ch
+    + Pseudofunctions _SetWindowBackColor and GlobalMemoryStatusEx.
 
 2019-08-28 17:17 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\ChangeLog_001.txt
-   * core\ChangeLog_002.txt
-   * core\ChangeLog_003.txt
-     ! Typos.
+  * core\ChangeLog_001.txt
+  * core\ChangeLog_002.txt
+  * core\ChangeLog_003.txt
+    ! Typos.
 
 2019-08-10 22:51 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\c_image.c
-     * Pacified some BCC compiler warnings.
+  * core\source\c_image.c
+    * Pacified some BCC compiler warnings.
 
 2019-08-10 22:50 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     * Pacified some MinGW CLang compiler warnings.
+  * core\source\bostaurus.prg
+    * Pacified some MinGW CLang compiler warnings.
 
 2019-08-10 22:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_windefs.ch
-     + Some treeview related notification codes.
+  * core\include\i_windefs.ch
+    + Some treeview related notification codes.
 
 2019-08-10 22:46 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_tree.ch
-   * core\source\h_tree.prg
-     + ON EXPAND and ON COLLAPSE events.
+  * core\include\i_tree.ch
+  * core\source\h_tree.prg
+    + ON EXPAND and ON COLLAPSE events.
 
 2019-08-10 22:44 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile.bat
-   * core\compile_MINGW.BAT
-     ! Wrong additional libraries prevent building harupdf sample.
+  * core\compile.bat
+  * core\compile_MINGW.BAT
+    ! Wrong additional libraries prevent building harupdf sample.
 
 2019-08-10 18:03 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_textbox.prg
-     ! The images of the action buttons are shown clipped.
+  * core\source\h_textbox.prg
+    ! The images of the action buttons are shown clipped.
 
 2019-08-10 10:24 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! Control's value must be set before calling ON DELETE event
-       handler to ensure that the grid is in a stable state.
+  * core\source\h_grid.prg
+    ! Control's value must be set before calling ON DELETE event
+      handler to ensure that the grid is in a stable state.
 
 2019-08-09 19:25 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_grid.ch
-     + Event ON BEFOREINSERT.
-       ; It's executed just before adding a new item to the grid.
-         For virtual grids, you can use this event to produce the
-         data that will be required by the new item.
-   * core\source\h_grid.prg
-     + OnBeforeInsert data to TGrid class.
-     ! Do not add items to virtual grids at Define method because
-       the item count is doubled.
-     + The related cell information is set before OnDelete event.
-       ; For virtual grids, you can use this event to discard the
-         data related to the delelted item.
-     * When deleting an item, the grid's value is now changed after
-       the execution of the OnDelete event instead of before.
+  * core\include\i_grid.ch
+    + Event ON BEFOREINSERT.
+    ; It's executed just before adding a new item to the grid.
+      For virtual grids, you can use this event to produce the
+      data that will be required by the new item.
+  * core\source\h_grid.prg
+    + OnBeforeInsert data to TGrid class.
+    ! Do not add items to virtual grids at Define method because
+      the item count is doubled.
+    + The related cell information is set before OnDelete event.
+    ; For virtual grids, you can use this event to discard the
+      data related to the delelted item.
+    * When deleting an item, the grid's value is now changed after
+      the execution of the OnDelete event instead of before.
 
 2019-08-07 17:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_grid.prg
-     ! RTE when adding or deleting rows of a virtual grid.
+  * core\source\h_grid.prg
+    ! RTE when adding or deleting rows of a virtual grid.
 
 2019-08-07 17:52 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\BuildApp_hbmk2.bat
-   * core\compile_MINGW.BAT
-   * core\resources\CompileRes_mingw.bat
-   * core\source\BuildLib_hbmk2.bat
-   * core\source\makelib_mingw.bat
-     ! Path is not properly restored if it contains & chars.
+  * core\BuildApp_hbmk2.bat
+  * core\compile_MINGW.BAT
+  * core\resources\CompileRes_mingw.bat
+  * core\source\BuildLib_hbmk2.bat
+  * core\source\makelib_mingw.bat
+    ! Path is not properly restored if it contains & chars.
 
 2019-08-02 20:30 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\winprint.ch
-     + BITMAP IMAGESIZE command.
-   * core\source\h_print.prg
-     + New parameter to PrintResource and PrintBitmap methods
-       of TPRINTBASE class.
-     + New parameter to PrintBitmapX method of THBPRINTER class.
-   * core\source\winprint.prg
-     + New parameter to Bitmap method of HBPRINTER class.
+  * core\include\winprint.ch
+    + BITMAP IMAGESIZE command.
+  * core\source\h_print.prg
+    + New parameter to PrintResource and PrintBitmap methods
+      of TPRINTBASE class.
+    + New parameter to PrintBitmapX method of THBPRINTER class.
+  * core\source\winprint.prg
+    + New parameter to Bitmap method of HBPRINTER class.
 
 2019-08-01 20:26 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_windefs.ch
-   * core\include\winprint.ch
-     ! Duplicated defines error when both file are included.
-   * core\source\c_image.c
-     * _OOHG_BITMAPFROMFILE function can now work without an object.
-   * core\source\h_print.prg
-     + Method PrintResource to class TPrintBase.
-       Use it to print an image from the resource file.
+  * core\include\i_windefs.ch
+  * core\include\winprint.ch
+    ! Duplicated defines error when both file are included.
+  * core\source\c_image.c
+    * _OOHG_BITMAPFROMFILE function can now work without an object.
+  * core\source\h_print.prg
+    + Method PrintResource to class TPrintBase.
+      Use it to print an image from the resource file.
 
 2019-07-31 19:57 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\bostaurus.prg
-     * Some format.
-     ! Release of the auxiliary mem DC.
+  * core\source\bostaurus.prg
+    * Some format.
+    ! Release of the auxiliary mem DC.
 
 2019-07-31 19:56 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\hbprinter_dyns.hbx
-     * Updated.
-   * core\include\winprint.ch
-     + BITMAP command for printing an image using its handle.
-   * core\source\h_image.prg
-     * Some format.
-     * Copy method does not honor its parameter.
-   * core\source\h_print.prg
-     + Methods PrintBitmap and PrintBitmapX to class TPRINTBASE .
-     + Method PrintBitmapX to class THBPRINTER.
-     ; Use oPrint:PrintBitmap( ... ) to print an image using
-       it's handle.
-   * core\source\winprint.prg
-     ! ASSIGN sentences are not compiled when NO_GUI is defined.
-     + Bitmap method of HBPRINTER class.
-     + ArrayIsValidColor static function at PRG level.
-     + RR_GETPIXELCOLOR and RR_DRAWBITMAP functions at C level.
+  * core\include\hbprinter_dyns.hbx
+    * Updated.
+  * core\include\winprint.ch
+    + BITMAP command for printing an image using its handle.
+  * core\source\h_image.prg
+    * Some format.
+    * Copy method does not honor its parameter.
+  * core\source\h_print.prg
+    + Methods PrintBitmap and PrintBitmapX to class TPRINTBASE .
+    + Method PrintBitmapX to class THBPRINTER.
+    ; Use oPrint:PrintBitmap( ... ) to print an image using
+      it's handle.
+  * core\source\winprint.prg
+    ! ASSIGN sentences are not compiled when NO_GUI is defined.
+    + Bitmap method of HBPRINTER class.
+    + ArrayIsValidColor static function at PRG level.
+    + RR_GETPIXELCOLOR and RR_DRAWBITMAP functions at C level.
 
 2019-07-26 20:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\compile_bcc.bat
-     ! Exe build with xHarbour+BCC fails to start with message
-       "no starting procedure".
+  * core\compile_bcc.bat
+    ! Exe build with xHarbour+BCC fails to start with message
+      "no starting procedure".
 
 2019-07-23 20:00 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\miniprint.prg
-     ! Print dialog does not respond to clicks.
+  * core\source\miniprint.prg
+    ! Print dialog does not respond to clicks.
 
 2019-07-20 16:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_spinner.ch
-     * Required clause was changed to optional. This allows to
-       change the order of the clauses without triggering a
-       compiler error.
+  * core\include\i_spinner.ch
+    * Required clause was changed to optional. This allows to
+      change the order of the clauses without triggering a
+      compiler error.
 
 2019-07-19 22:48 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_report.prg
-     ! RTE when memvar _OOHG_PrintLibrary is not defined.
-     ! RTE because aLines is not defined.
-     ! IMAGE clause is ignored when parsing a report file.
+  * core\source\h_report.prg
+    ! RTE when memvar _OOHG_PrintLibrary is not defined.
+    ! RTE because aLines is not defined.
+    ! IMAGE clause is ignored when parsing a report file.
 
 2019-07-19 22:32 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     + Added data TYPE to each subclass of TPrintBase.
-       If you have a TPrint object named oPrint, you can identify
-       it's subclass using oPrint:Type.
+  * core\source\h_print.prg
+    + Added data TYPE to each subclass of TPrintBase.
+      If you have a TPrint object named oPrint, you can identify
+      it's subclass using oPrint:Type.
 
 2019-07-18 20:15 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\oohg.hbc
-     + Switch mt (because it's oohg specific).
-     - Switch gtgui (must be used in .hbp file).
-     * Some comments.
+  * core\oohg.hbc
+    + Switch mt (because it's oohg specific).
+    - Switch gtgui (must be used in .hbp file).
+    * Some comments.
 
 2019-07-18 20:14 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\oohg.ch
-     + Two requests to fix building with Harbour 3.4
-       compiled with clang compiler.
+  * core\include\oohg.ch
+    + Two requests to fix building with Harbour 3.4
+      compiled with clang compiler.
 
 2019-07-18 20:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\include\i_window.ch
-     + Support for NoDefWinProc property.
-     + Support for NODWP clause.
+  * core\include\i_window.ch
+    + Support for NoDefWinProc property.
+    + Support for NODWP clause.
 
-   * core\source\h_application.prg
-     + Support for a global modal hidden window.
+  * core\source\h_application.prg
+    + Support for a global modal hidden window.
 
-   * core\source\h_windows.prg
-     + DATA NoDefWinProc.
-       Defaults to .F.
-       When set to .T., the WM_PAINT handler will not call
-       function DefWindowProc at it's beginning but at it's end.
+  * core\source\h_windows.prg
+    + DATA NoDefWinProc.
+      Defaults to .F.
+      When set to .T., the WM_PAINT handler will not call
+      function DefWindowProc at it's beginning but at it's end.
 
-   * core\source\h_form.prg
-     * Reverted the change to WM_PAINT handler's default behavior
-       done by commit 2019-02-17 11:36 UTC-0300 (hash 0073c75).
-     ! This reversion fixes miniprint's not displaying the
-       document in the preview window.
-     * This reversion breaks code based on BosTaurus functions
-       that paint on the form at ON PAINT event.
-       To fix the code you must add the NODWP clause to the form
-       or set to .T. it's NoDefWinProc data.
-       See samples\bostaurus folder.
-       INCOMPATIBLE
-     + Support for NoDefWinProc switch at WM_PAINT handler to
-       alter it's default behavior.
+  * core\source\h_form.prg
+    * Reverted the change to WM_PAINT handler's default behavior
+      done by commit 2019-02-17 11:36 UTC-0300 (hash 0073c75).
+    ! This reversion fixes miniprint's not displaying the
+      document in the preview window.
+    * This reversion breaks code based on BosTaurus functions
+      that paint on the form at ON PAINT event.
+      To fix the code you must add the NODWP clause to the form
+      or set to .T. it's NoDefWinProc data.
+      See samples\bostaurus folder.
+      INCOMPATIBLE
+    + Support for NoDefWinProc switch at WM_PAINT handler to
+      alter it's default behavior.
 
-   * core\source\h_print.prg
-     ! RTE at method BeginDoc.
-     ! RTE at method EndDoc.
-     ! Wrong default value of SelPrinter's preview parameter.
-     ! Wrong default value of EndDoc's wait parameter.
+  * core\source\h_print.prg
+    ! RTE at method BeginDoc.
+    ! RTE at method EndDoc.
+    ! Wrong default value of SelPrinter's preview parameter.
+    ! Wrong default value of EndDoc's wait parameter.
 
-   * core\source\miniprint.prg
-     * Minor simplifications.
-     ! Preview form can't be restored after minimizing it to the taskbar.
+  * core\source\miniprint.prg
+    * Minor simplifications.
+    ! Preview form can't be restored after minimizing it to the taskbar.
 
-   * core\source\winprint.prg
-     ! Minor simplifications.
-     ! Preview form can't be restored after minimizing it to the taskbar.
+  * core\source\winprint.prg
+    ! Minor simplifications.
+    ! Preview form can't be restored after minimizing it to the taskbar.
 
 2019-07-18 20:11 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_pdf.prg
-     ! Wrong line's thickness.
+  * core\source\h_pdf.prg
+    ! Wrong line's thickness.
 
 2019-06-24 19:27 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\winprint.prg
-     ! RTE 1132 "Array access error" at HBPRINTER:ENDDOC line 425.
+  * core\source\winprint.prg
+    ! RTE 1132 "Array access error" at HBPRINTER:ENDDOC line 425.
 
 2019-03-20 22:28 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
-   * core\source\h_print.prg
-     ! Restored _modalhide window at method BeginDoc. It's needed
-       in case no MAIN window is defined to avoid and RTE.
-     + Some validations to avoid an RTE if ::oWinReport is not
-       defined at method EndDoc.
-     ! Missing CLASS clause at TPDFPRINT's MaxCol and MaxRow methods.
+  * core\source\h_print.prg
+    ! Restored _modalhide window at method BeginDoc. It's needed
+      in case no MAIN window is defined to avoid and RTE.
+    + Some validations to avoid an RTE if ::oWinReport is not
+      defined at method EndDoc.
+    ! Missing CLASS clause at TPDFPRINT's MaxCol and MaxRow methods.
 
 2019-03-20 21:13 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
   * core\ChangeLog_006.txt

--- a/source/h_application.prg
+++ b/source/h_application.prg
@@ -65,6 +65,8 @@
 #include "oohg.ch"
 #include "i_init.ch"
 
+#define MAX_OBJ_NUMBER   9999999999
+
 #define HOTKEY_ID        1
 #define HOTKEY_MOD       2
 #define HOTKEY_KEY       3
@@ -1975,8 +1977,8 @@ METHOD Value_Pos50( cValue ) CLASS TApplication
       // Caller must verify this name doesn't exists
       uRet := "NULL" + StrZero( ::aVars[ NDX_OOHG_GETNULLNAME ], 10 )
       ::aVars[ NDX_OOHG_GETNULLNAME ] ++
-      IF ::aVars[ NDX_OOHG_GETNULLNAME ] > 9999999999
-         ::aVars[ NDX_OOHG_GETNULLNAME ] := 0
+      IF ::aVars[ NDX_OOHG_GETNULLNAME ] > MAX_OBJ_NUMBER
+         MsgOOHGError( "APPLICATION: Can't assign a new NULL name." )
       ENDIF
    ENDIF
    ::MutexUnlock()

--- a/source/h_button.prg
+++ b/source/h_button.prg
@@ -220,7 +220,9 @@ METHOD Define( cControlName, uParentForm, nCol, nRow, cCaption, bAction, nWidth,
 
    IF HB_ISLOGICAL( lDrawBy )
       ::lLibDraw := lDrawBy
-   ELSEIF ::lNoFocusRect .OR. ::lNoHotLight .OR. ::lFitTxt .OR. ::lNoPrintOver .OR. ::lSolid .OR. ValType( aTextMargin ) $ "AN"
+   ELSEIF ::lNoFocusRect .OR. ::lNoHotLight .OR. ::lFitTxt .OR. ::lNoPrintOver
+      ::lLibDraw := .T.
+   ELSEIF uFontColor # NIL .OR. ::lSolid .OR. ValType( aTextMargin ) $ "AN"
       ::lLibDraw := .T.
    ELSE
       ::lLibDraw := _OOHG_UseLibraryDraw

--- a/source/h_checkbox.prg
+++ b/source/h_checkbox.prg
@@ -111,6 +111,10 @@ METHOD Define( cControlName, uParentForm, nCol, nRow, cCaption, uValue, cFontNam
       ::lLibDraw := lDrawBy
    ELSEIF ::lNoFocusRect
       ::lLibDraw := .T.
+   ELSEIF ::lNoFocusRect .OR. uFontColor # NIL
+      ::lLibDraw := .T.
+   ELSE
+      ::lLibDraw := _OOHG_UseLibraryDraw
    ENDIF
 
    ::SetForm( cControlName, uParentForm, cFontName, cFontSize, uFontColor, uBackColor, NIL, lRtl )
@@ -156,7 +160,7 @@ METHOD Value( uValue ) CLASS TCheckBox
    Local uState
 
    IF HB_ISLOGICAL( uValue )
-      SendMessage( ::hWnd, BM_SETCHECK, if( uValue, BST_CHECKED, BST_UNCHECKED ), 0 )
+      SendMessage( ::hWnd, BM_SETCHECK, iif( uValue, BST_CHECKED, BST_UNCHECKED ), 0 )
       ::DoChange()
    ELSEIF ::ThreeState .AND. PCount() > 0 .AND. uValue == NIL
       SendMessage( ::hWnd, BM_SETCHECK, BST_INDETERMINATE, 0 )
@@ -203,7 +207,7 @@ METHOD Events_Notify( wParam, lParam ) CLASS TCheckBox
       IF ::lLibDraw .AND. ::IsVisualStyled
          RETURN TCheckBox_Notify_CustomDraw( Self, lParam, ::Caption, ;
                                              ( HB_ISOBJECT( ::TabHandle ) .AND. ! HB_ISOBJECT( ::oBkGrnd ) ), ;
-                                             ::LeftAlign, ::lNoFocusRect )
+                                             ::LeftAlign, ::lNoFocusRect)
       ENDIF
    ENDIF
 

--- a/source/h_radio.prg
+++ b/source/h_radio.prg
@@ -100,6 +100,7 @@ CLASS TRadioGroup FROM TLabel
    METHOD ItemReadOnly
    METHOD ItemToolTip
    METHOD Limit                    SETGET
+   METHOD oBkGrnd                  SETGET
    METHOD ReadOnly                 SETGET
    METHOD RePaint
    METHOD RowMargin                BLOCK { |Self| - ::Row }
@@ -141,6 +142,10 @@ METHOD Define( cControlName, uParentForm, nCol, nRow, aOptions, uValue, cFontNam
       ::lLibDraw := lDrawBy
    ELSEIF ::lNoFocusRect
       ::lLibDraw := .T.
+   ELSEIF uFontColor # NIL
+      ::lLibDraw := .T.
+   ELSE
+      ::lLibDraw := _OOHG_UseLibraryDraw
    ENDIF
 
    IF HB_ISNUMERIC( nSpacing )
@@ -208,18 +213,26 @@ METHOD Define( cControlName, uParentForm, nCol, nRow, aOptions, uValue, cFontNam
    RETURN Self
 
 /*--------------------------------------------------------------------------------------------------------------------------------*/
-METHOD Background( oBkGrnd ) CLASS TRadioGroup
+METHOD Background( oCtrl ) CLASS TRadioGroup
+
+   RETURN ::oBkGrnd( oCtrl )
+
+/*--------------------------------------------------------------------------------------------------------------------------------*/
+METHOD oBkGrnd( oCtrl ) CLASS TRadioGroup
 
    LOCAL i
 
-   IF HB_ISOBJECT( oBkGrnd )
-      ::oBkGrnd := oBkGrnd
-      FOR i := 1 TO Len( ::aOptions )
-         ::aOptions[ i ]:Background := oBkGrnd
-      NEXT
+   IF PCount() > 0
+      IF oCtrl == NIL .OR. HB_ISOBJECT( oCtrl )
+         ::BrushHandle := NIL
+         ::BackgroundObject := oCtrl
+         FOR i := 1 TO Len( ::aOptions )
+            ::aOptions[ i ]:oBkGrnd := oCtrl
+         NEXT
+      ENDIF
    ENDIF
 
-   RETURN ::oBkGrnd
+   RETURN ::BackgroundObject
 
 /*--------------------------------------------------------------------------------------------------------------------------------*/
 METHOD GroupHeight() CLASS TRadioGroup
@@ -825,6 +838,11 @@ METHOD Define( cControlName, uParentForm, nCol, nRow, nWidth, nHeight, cCaption,
    RETURN Self
 
 /*--------------------------------------------------------------------------------------------------------------------------------*/
+METHOD Background( oCtrl ) CLASS TRadioItem
+
+   RETURN ::oBkGrnd( oCtrl )
+
+/*--------------------------------------------------------------------------------------------------------------------------------*/
 METHOD Value( lValue ) CLASS TRadioItem
 
    LOCAL lOldValue
@@ -837,16 +855,6 @@ METHOD Value( lValue ) CLASS TRadioItem
    ENDIF
 
    RETURN ( SendMessage( ::hWnd, BM_GETCHECK, 0, 0 ) == BST_CHECKED )
-
-/*--------------------------------------------------------------------------------------------------------------------------------*/
-METHOD Background( oBkGrnd ) CLASS TRadioItem
-
-   IF HB_ISOBJECT( oBkGrnd )
-      ::oBkGrnd := oBkGrnd
-      ::Redraw()
-   ENDIF
-
-   RETURN ::oBkGrnd
 
 /*--------------------------------------------------------------------------------------------------------------------------------*/
 METHOD Events( hWnd, nMsg, wParam, lParam ) CLASS TRadioItem


### PR DESCRIPTION
If neither WINDRAW nor OOHGDRAW clauses are present then the first one will be assumed when a clause that requires it is added to the control's definition.
Fixed: painting a control transparently over an image was leaving the focus rectangle.
Improved setting and removing of background object.
