### PR TITLE
__TA_DEFINED for group TA_ because errors on mingw

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -13,6 +13,10 @@
  * Use #nnn to refer to an issue.
  * Use #nnn-PRG to refer to a pull request.
  */
+2025-11-20 20:09 UTC-0200 Jose Quintas <jmcquintas@gmail.com>
+   * include\miniprint.ch
+   * include\winprint.ch
+     #define __TA_DEFINED for group TA_ because errors on mingw
 
 2025-11-02 22:53 UTC-0300 Fernando Yurisich <fyurisich@oohg.org>
   * core\include\i_textbox.ch

--- a/include/miniprint.ch
+++ b/include/miniprint.ch
@@ -803,8 +803,9 @@ PRINTER CONFIGURATION CONSTANTS
 #define WIN_PRINTER_STATUS_POWER_SAVE               0x01000000
 #endif
 
+#endif
 /* text alignment */
-#ifndef __HBPRN__
+#ifndef __TA_DEFINED
 #define TA_NOUPDATECP                               0
 #define TA_UPDATECP                                 1
 #define TA_LEFT                                     0
@@ -815,7 +816,7 @@ PRINTER CONFIGURATION CONSTANTS
 #define TA_BASELINE                                 24
 #define TA_RTLREADING                               256
 #define TA_MASK                                     ( TA_BASELINE + TA_CENTER + TA_UPDATECP + TA_RTLREADING )
+#define __TA_DEFINED
 #endif
 
-#endif
 

--- a/include/winprint.ch
+++ b/include/winprint.ch
@@ -900,7 +900,7 @@ POLYFILL() MODES
 TEXT ALIGNMENT OPTIONS
 ---------------------------------------------------------------------------*/
 
-#ifndef __MINIPRINT__
+#ifndef __TA_DEFINED
 #define TA_NOUPDATECP                         0
 #define TA_UPDATECP                           1
 #define TA_LEFT                               0
@@ -912,6 +912,7 @@ TEXT ALIGNMENT OPTIONS
 #define TA_RTLREADING                         256
 #define TA_MASK                               ( TA_BASELINE + TA_CENTER + TA_UPDATECP + TA_RTLREADING )
 #define GDI_ERROR                             0xFFFFFFFF
+#define __TA_DEFINED
 #endif
 
 /*---------------------------------------------------------------------------


### PR DESCRIPTION
Because of warnings on miniprint.prg and h_print.prg
For some reason, previous ch was not creating the variables TA_ 